### PR TITLE
use skimage for reading psf tiff files

### DIFF
--- a/core/lls_core/deconvolution.py
+++ b/core/lls_core/deconvolution.py
@@ -64,8 +64,8 @@ def read_psf(psf_paths: Collection[Path],
                 #Use skimage to read tiff
                 if psf.suffix in [".tif", ".tiff"]:
                     psf_aics_data = imread(str(psf))
-                    assert len(
-                    psf_aics_data.shape) == 3, f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}"
+                   if len(psf_aics_data.shape) != 3:
+                       raise ValueError(f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}")
                 else:
                     #Use AICSImageIO
                     psf_aics = AICSImage(str(psf))

--- a/core/lls_core/deconvolution.py
+++ b/core/lls_core/deconvolution.py
@@ -68,7 +68,7 @@ def read_psf(psf_paths: Collection[Path],
                     psf_aics_data.shape) == 3, f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}"
                 else:
                     #Use AICSImageIO
-                    psf_aics = AICSImage(psf.__str__())
+                    psf_aics = AICSImage(str(psf))
                     psf_aics_data = psf_aics.data[0][0]
                     psf_aics_data = pad_image_nearest_multiple(
                         img=psf_aics_data, nearest_multiple=16)           

--- a/core/lls_core/deconvolution.py
+++ b/core/lls_core/deconvolution.py
@@ -61,19 +61,20 @@ def read_psf(psf_paths: Collection[Path],
                 # pad psf to multiple of 16 for decon
                 yield pad_image_nearest_multiple(img=psf_aics, nearest_multiple=16)
             else:
+                #Use skimage to read tiff
                 if psf.suffix in [".tif", ".tiff"]:
                     psf_aics_data = imread(psf.__str__())
                     assert len(
                     psf_aics_data.shape) == 3, f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}"
                 else:
+                    #Use AICSImageIO
                     psf_aics = AICSImage(psf.__str__())
                     psf_aics_data = psf_aics.data[0][0]
-                psf_aics_data = pad_image_nearest_multiple(
-                    img=psf_aics_data, nearest_multiple=16)
-
-                if psf_aics.dims.C != lattice_class.channels:
-                    logger.warn(
-                        f"PSF image has {psf_channels} channel/s, whereas image has {lattice_class.channels}")
+                    psf_aics_data = pad_image_nearest_multiple(
+                        img=psf_aics_data, nearest_multiple=16)           
+                    if psf_aics.dims.C != lattice_class.channels:
+                        logger.warn(
+                            f"PSF image has {psf_channels} channel/s, whereas image has {lattice_class.channels}")
 
                 yield psf_aics_data
 

--- a/core/lls_core/deconvolution.py
+++ b/core/lls_core/deconvolution.py
@@ -63,7 +63,7 @@ def read_psf(psf_paths: Collection[Path],
             else:
                 #Use skimage to read tiff
                 if psf.suffix in [".tif", ".tiff"]:
-                    psf_aics_data = imread(psf.__str__())
+                    psf_aics_data = imread(str(psf))
                     assert len(
                     psf_aics_data.shape) == 3, f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}"
                 else:

--- a/core/lls_core/deconvolution.py
+++ b/core/lls_core/deconvolution.py
@@ -63,7 +63,7 @@ def read_psf(psf_paths: Collection[Path],
             else:
                 #Use skimage to read tiff
                 if psf.suffix in [".tif", ".tiff"]:
-                    psf_aics_data = imread(str(psf))
+                   psf_aics_data = imread(str(psf))
                    if len(psf_aics_data.shape) != 3:
                        raise ValueError(f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}")
                 else:

--- a/core/lls_core/deconvolution.py
+++ b/core/lls_core/deconvolution.py
@@ -6,6 +6,7 @@ import logging
 import importlib.util
 from typing import Collection, Iterable,Union,Literal
 from aicsimageio import AICSImage
+from skimage.io import imread
 from aicspylibczi import CziFile
 from numpy.typing import NDArray
 import os
@@ -60,8 +61,13 @@ def read_psf(psf_paths: Collection[Path],
                 # pad psf to multiple of 16 for decon
                 yield pad_image_nearest_multiple(img=psf_aics, nearest_multiple=16)
             else:
-                psf_aics = AICSImage(psf.__str__())
-                psf_aics_data = psf_aics.data[0][0]
+                if psf.suffix in [".tif", ".tiff"]:
+                    psf_aics_data = imread(psf.__str__())
+                    assert len(
+                    psf_aics_data.shape) == 3, f"PSF should be a 3D image (shape of 3), but got {psf_aics.shape}"
+                else:
+                    psf_aics = AICSImage(psf.__str__())
+                    psf_aics_data = psf_aics.data[0][0]
                 psf_aics_data = pad_image_nearest_multiple(
                     img=psf_aics_data, nearest_multiple=16)
 

--- a/plugin/napari_lattice/_reader.py
+++ b/plugin/napari_lattice/_reader.py
@@ -76,12 +76,15 @@ def napari_get_reader(path: list[str] | str):
         # if it is a list, we are only going to open first file
         path = path[0]
 
+    tiff_formats = (".tif",".tiff")
+    
+    if path.endswith(".h5"):
+        return bdv_h5_reader
+    elif path.endswith(tiff_formats):
+        return tiff_reader
     # if we know we cannot read the file, we immediately return None.
-    if not path.endswith(".h5"):
+    else:
         return None
-
-    # otherwise we return the *function* that can read ``path``.
-    return bdv_h5_reader
 
 
 def bdv_h5_reader(path):
@@ -138,3 +141,24 @@ def bdv_h5_reader(path):
 
     layer_type = "image"  # optional, default is "image"
     return [(images, add_kwargs, layer_type)]
+
+
+def tiff_reader(path):
+    """Take path to tiff image and returns a list of LayerData tuples.
+    Specifying tiff_reader to have better control over tifffile related errors when using AICSImage
+    """
+    
+    try:
+        image = AICSImage(path)
+    except Exception:
+        import sys
+        exception = sys.exc_info()[0]
+        print("Error Reading Tiff: ", sys.exc_info()[
+                0], "has occurred. Try upgrading tifffile library: pip install tifffile --upgrade.")
+        raise
+
+    # optional kwargs for the corresponding viewer.add_* method
+    add_kwargs = {}
+
+    layer_type = "image"  # optional, default is "image"
+    return [(image, add_kwargs, layer_type)]

--- a/plugin/napari_lattice/_reader.py
+++ b/plugin/napari_lattice/_reader.py
@@ -16,10 +16,10 @@ from napari.layers import image, Layer
 from napari.layers._data_protocols import LayerDataProtocol
 
 from typing_extensions import Literal
-from typing import Any, Optional, cast, TYPE_CHECKING
+from typing import Any, Optional, cast, TYPE_CHECKING, Tuple, List
 
 from lls_core.lattice_data import lattice_from_aics, LatticeData, img_from_array
-from aicsimageio.types import ArrayLike
+from aicsimageio.types import ArrayLike, ImageLike
 
 if TYPE_CHECKING:
     from aicsimageio.aics_image import AICSImage
@@ -143,19 +143,15 @@ def bdv_h5_reader(path):
     return [(images, add_kwargs, layer_type)]
 
 
-def tiff_reader(path):
+def tiff_reader(path: ImageLike) -> List[Tuple[AICSImage, dict, str]]:
     """Take path to tiff image and returns a list of LayerData tuples.
     Specifying tiff_reader to have better control over tifffile related errors when using AICSImage
     """
     
     try:
         image = AICSImage(path)
-    except Exception:
-        import sys
-        exception = sys.exc_info()[0]
-        print("Error Reading Tiff: ", sys.exc_info()[
-                0], "has occurred. Try upgrading tifffile library: pip install tifffile --upgrade.")
-        raise
+    except Exception as e:
+        raise Exception("Error reading TIFF. Try upgrading tifffile library: pip install tifffile --upgrade.") from e
 
     # optional kwargs for the corresponding viewer.add_* method
     add_kwargs = {}


### PR DESCRIPTION
Reduce dependency on tifffile library as much as possible.
aicsimageio depends on tifffile for reading tiffs, but most [2023.3.15](https://github.com/cgohlke/tifffile/releases/tag/v2023.3.15) is giving errors. For example: https://forum.image.sc/t/napari-performance-on-a-tb-czi-image/84587/10?u=pr4deepr

Also, see: https://github.com/AllenCellModeling/aicsimageio/issues/523
