### PR TITLE
Use pydantic compatibility layer

### DIFF
--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -20,7 +20,7 @@ from typer import Typer, Argument, Option, Context, Exit
 from typer.main import get_command
 
 from lls_core.models.output import SaveFileType
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 if TYPE_CHECKING:
     from lls_core.models.utils import FieldAccessModel

--- a/core/lls_core/models/crop.py
+++ b/core/lls_core/models/crop.py
@@ -1,5 +1,5 @@
 from typing_extensions import Any, Iterable, List, Tuple
-from pydantic import Field, NonNegativeInt, validator
+from pydantic.v1 import Field, NonNegativeInt, validator
 from lls_core.models.utils import FieldAccessModel
 from lls_core.cropping import Roi
 

--- a/core/lls_core/models/deconvolution.py
+++ b/core/lls_core/models/deconvolution.py
@@ -1,5 +1,5 @@
 
-from pydantic import Field, NonNegativeInt, validator
+from pydantic.v1 import Field, NonNegativeInt, validator
 
 from typing_extensions import Any, List, Literal, Union
 

--- a/core/lls_core/models/deskew.py
+++ b/core/lls_core/models/deskew.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 # class for initializing lattice data and setting metadata
 # TODO: handle scenes
-from pydantic import Field, NonNegativeFloat, validator, root_validator
+from pydantic.v1 import Field, NonNegativeFloat, validator, root_validator
 
 from typing_extensions import Self, TYPE_CHECKING, Any, Tuple
 

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 # class for initializing lattice data and setting metadata
 # TODO: handle scenes
-from pydantic import Field, root_validator, validator
+from pydantic.v1 import Field, root_validator, validator
 from dask.array.core import Array as DaskArray
 
 from typing_extensions import Any, Iterable, Optional, TYPE_CHECKING, Type

--- a/core/lls_core/models/output.py
+++ b/core/lls_core/models/output.py
@@ -1,4 +1,4 @@
-from pydantic import Field, DirectoryPath, validator
+from pydantic.v1 import Field, DirectoryPath, validator
 from strenum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from typing import Iterable, Optional, Tuple, Union, cast, TYPE_CHECKING, overload
 from typing_extensions import Generic, TypeVar
-from pydantic import BaseModel, NonNegativeInt, Field
+from pydantic.v1 import BaseModel, NonNegativeInt, Field
 from lls_core.types import ArrayLike, is_arraylike
 from lls_core.utils import make_filename_suffix
 from lls_core.writers import RoiIndex, Writer

--- a/core/lls_core/models/utils.py
+++ b/core/lls_core/models/utils.py
@@ -2,7 +2,7 @@
 from typing import Any, Type
 from typing_extensions import Self
 from enum import Enum
-from pydantic import BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 from contextlib import contextmanager
 
 def enum_choices(enum: Type[Enum]) -> str:

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from lls_core.types import ArrayLike
 
-from pydantic import NonNegativeInt
+from pydantic.v1 import NonNegativeInt
 
 from lls_core.utils import make_filename_suffix
 RoiIndex = Optional[NonNegativeInt]

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -51,7 +51,9 @@ dependencies = [
     "pandas",
     "pyclesperanto_prototype>=0.20.0",
     "pyopencl",
-    "pydantic~=1.0",
+    # This is the first pydantic version that supports the "compatibility mode"
+    # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
+    "pydantic>=1.10.17",
     "pyyaml",
     "read-roi",
     "rich",

--- a/core/tests/test_validation.py
+++ b/core/tests/test_validation.py
@@ -4,7 +4,7 @@ from lls_core.models.lattice_data import LatticeData
 from lls_core.models.deskew import DeskewParams
 from lls_core.models.output import OutputParams
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 import tempfile
 from unittest.mock import patch, PropertyMock
 

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -51,7 +51,7 @@ def exception_to_html(e: BaseException) -> str:
     """
     Converts an exception to HTML for reporting back to the user
     """
-    from pydantic import ValidationError
+    from pydantic.v1 import ValidationError
     if isinstance(e, ValidationError):
         message = []
         for error in e.errors():

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "napari-spreadsheet",
     "napari-workflow-inspector",
     "napari-workflows>=0.2.8",
-    "napari>=0.4.11,<0.5",
+    "napari>=0.4.11",
     "npy2bdv",
     "numpy",
     "psutil",


### PR DESCRIPTION
I've unpinned `napari` and `pydantic`, according to the [instructions here](https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment). This should give us much better compatibility.

Closes #57.