### PR TITLE
Fix #66

### DIFF
--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -12,7 +12,7 @@ from lls_core.models.crop import CropParams
 from lls_core.models.deconvolution import DeconvolutionParams
 from lls_core.models.output import OutputParams, SaveFileType
 from lls_core.models.results import WorkflowSlices
-from lls_core.models.utils import ignore_keyerror
+from lls_core.models.utils import as_tuple, ignore_keyerror
 from lls_core.types import ArrayLike
 from lls_core.models.deskew import DeskewParams
 from napari_workflows import Workflow
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 import logging
 
 logger = logging.getLogger(__name__)
+
 
 class LatticeData(OutputParams, DeskewParams):
     """
@@ -443,8 +444,7 @@ class LatticeData(OutputParams, DeskewParams):
         for workflow in self.generate_workflows():
             outputs.append(
                 workflow.copy_with_data(
-                    # Evaluates the workflow here.
-                    workflow.data.get(get_workflow_output_name(workflow.data))
+                    lambda: as_tuple(workflow.data.get(get_workflow_output_name(workflow.data)))
                 )
             )
 

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -350,11 +350,13 @@ class LatticeData(OutputParams, DeskewParams):
         """
         Yields processed image slices with cropping enabled
         """
+        from tqdm import tqdm
+
         if self.crop is None:
             raise Exception("This function can only be called when crop is set")
             
         # We have an extra level of iteration for the crop path: iterating over each ROI
-        for roi_index, roi in enumerate(tqdm(self.crop.selected_rois, desc="ROI", position=0)):
+        for roi_index, roi in enumerate(tqdm(self.crop.selected_rois, total=len(self.crop.roi_subset), desc="ROI", position=0)):
             # pass arguments for save tiff, callable and function arguments
             logger.info(f"Processing ROI {self.crop.roi_subset[roi_index]}")
             

--- a/core/lls_core/models/output.py
+++ b/core/lls_core/models/output.py
@@ -72,10 +72,7 @@ class OutputParams(FieldAccessModel):
         """
         Returns a filepath for the non-image data
         """
-        if isinstance(result, DataFrame):
-            return self.get_unique_filepath(self.save_dir / Path(self.save_name + suffix).with_suffix(".csv"))
-        
-        return 
+        return self.get_unique_filepath(self.save_dir / Path(self.save_name + suffix).with_suffix(".csv"))
     
     def get_unique_filepath(self, path: Path) -> Path:
         """

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -111,7 +111,13 @@ class ProcessedWorkflowOutput(BaseModel, arbitrary_types_allowed=True):
         from pandas import Series
 
         if isinstance(self.data, DataFrame):
-            path: Path = self.lattice_data.make_filepath_df(make_filename_suffix(roi_index=str(self.roi_index), prefix=f"_output_{self.index}"), self.data)
+            path: Path = self.lattice_data.make_filepath_df(
+                make_filename_suffix(
+                    roi_index=self.roi_index,
+                    prefix=f"_output_{self.index}"
+                ),
+                self.data
+            )
             result = self.data.apply(Series.explode)
             result.to_csv(str(path))
             return path

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 from itertools import groupby
 from pathlib import Path
 
-from typing import Callable, Iterable, Optional, Tuple, TypeAlias, Union, cast, TYPE_CHECKING, overload
-from typing_extensions import Generic, TypeVar
+from typing import Callable, Iterable, Optional, Tuple, Union, cast, TYPE_CHECKING
+from typing_extensions import Generic, TypeVar, TypeAlias
 from pydantic.v1 import BaseModel, NonNegativeInt, Field
 from lls_core.types import ArrayLike, is_arraylike
 from lls_core.utils import make_filename_suffix

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -41,18 +41,6 @@ class ProcessedSlice(BaseModel, Generic[T], arbitrary_types_allowed=True):
                 "data": data
             })
         )
-    
-    @overload
-    def as_tuple(self: ProcessedSlice[Tuple[R]]) -> Tuple[R]:
-        ...
-    @overload
-    def as_tuple(self: ProcessedSlice[T]) -> Tuple[T]:
-        ...
-    def as_tuple(self):
-        """
-        Converts the results to a tuple if they weren't already
-        """
-        return self.data if isinstance(self.data, (tuple, list)) else (self.data,)
 
 class ProcessedSlices(BaseModel, Generic[T], arbitrary_types_allowed=True):
     """

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -134,7 +134,7 @@ class WorkflowSlices(ProcessedSlices[UnevaluatedWorkflowOutput]):
     """
 
     # This re-definition of the type is helpful for `mkdocs`
-    slices: Iterable[ProcessedSlice[UnevaluatedWorkflowOutput]] = Field(description="Iterable of raw workflow results, the exact nature of which is determined by the author of the workflow. Not typically useful directly, and using the result of `.process()` is recommended instead.")
+    slices: Iterable[ProcessedSlice[UnevaluatedWorkflowOutput]] = Field(description="Iterable of functions. Each of these functions evaluates to a tuple of raw workflow results, the exact nature of which is determined by the author of the workflow. Not typically useful directly, and using the result of `.process()` is recommended instead.")
 
     def process(self) -> Iterable[ProcessedWorkflowOutput]:
         """

--- a/core/lls_core/models/utils.py
+++ b/core/lls_core/models/utils.py
@@ -1,9 +1,16 @@
 
-from typing import Any, Type
+from typing import Any, Tuple, Type, TypeVar
 from typing_extensions import Self
 from enum import Enum
 from pydantic.v1 import BaseModel, Extra
 from contextlib import contextmanager
+
+T = TypeVar("T")
+def as_tuple(x: Tuple[T] | T) -> Tuple[T]:
+    """
+    Converts the results to a tuple if they weren't already
+    """
+    return x if isinstance(x, tuple) else (x,)
 
 def enum_choices(enum: Type[Enum]) -> str:
     """

--- a/core/lls_core/models/utils.py
+++ b/core/lls_core/models/utils.py
@@ -1,12 +1,12 @@
 
-from typing import Any, Tuple, Type, TypeVar
+from typing import Any, Tuple, Type, TypeVar, Union
 from typing_extensions import Self
 from enum import Enum
 from pydantic.v1 import BaseModel, Extra
 from contextlib import contextmanager
 
 T = TypeVar("T")
-def as_tuple(x: Tuple[T] | T) -> Tuple[T]:
+def as_tuple(x: Union[Tuple[T], T]) -> Tuple[T]:
     """
     Converts the results to a tuple if they weren't already
     """

--- a/core/lls_core/utils.py
+++ b/core/lls_core/utils.py
@@ -320,7 +320,7 @@ def array_to_dask(arr: ArrayLike) -> DaskArray:
     else:
         return from_array(arr)
 
-def make_filename_suffix(prefix: Optional[str] = None, roi_index: Optional[str] = None, channel: Optional[str] = None, time: Optional[str] = None) -> str:
+def make_filename_suffix(prefix: Optional[str] = None, roi_index: Optional[int] = None, channel: Optional[str] = None, time: Optional[str] = None) -> str:
     """
     Generates a filename for this result
     """

--- a/core/tests/test_process.py
+++ b/core/tests/test_process.py
@@ -116,7 +116,7 @@ def test_process_workflow(
 
     workflow: Workflow = request.getfixturevalue(workflow_name)
     with tempfile.TemporaryDirectory() as tmpdir:
-        for roi, output in (
+        for output in (
             LatticeData.parse_obj(
                 {
                     "input_image": root / "raw.tif",
@@ -128,8 +128,8 @@ def test_process_workflow(
             .process_workflow()
             .process()
         ):
-            assert roi is None or isinstance(roi, int)
-            assert isinstance(output, (Path, DataFrame))
+            assert output.roi_index is None or isinstance(output.roi_index, int)
+            assert isinstance(output.data, (Path, DataFrame))
 
 def test_table_workflow(
     rbc_tiny: Path, table_workflow: Workflow

--- a/core/tests/test_workflows.py
+++ b/core/tests/test_workflows.py
@@ -56,13 +56,13 @@ def test_workflow_cli(workflow_config_cli: dict, save_func: Callable, cli_param:
 def test_image_workflow(minimal_image_path: Path, image_workflow: Workflow):
     # Test that a regular workflow that returns an image directly works
     with tempfile.TemporaryDirectory() as tmpdir:
-        for roi, output in LatticeData(
+        for output in LatticeData(
             input_image = minimal_image_path,
             workflow = image_workflow,
             save_dir = tmpdir
         ).process_workflow().process():
-            assert isinstance(output, Path)
-            assert valid_image_path(output)
+            assert isinstance(output.data, Path)
+            assert valid_image_path(output.data)
 
 def test_table_workflow(minimal_image_path: Path, table_workflow: Workflow):
     # Test a complex workflow that returns a tuple of images and data
@@ -72,17 +72,18 @@ def test_table_workflow(minimal_image_path: Path, table_workflow: Workflow):
             workflow = table_workflow,
             save_dir = tmpdir
         )
-        for _roi, output in params.process_workflow().process():
-            assert isinstance(output, (DataFrame, Path))
-            if isinstance(output, DataFrame):
-                nrow, ncol = output.shape
+        for output in params.process_workflow().process():
+            data = output.data
+            assert isinstance(data, (DataFrame, Path))
+            if isinstance(data, DataFrame):
+                nrow, ncol = data.shape
                 assert nrow == params.nslices
                 assert ncol > 0
                 # Check that time and channel are included
-                assert output.iloc[0, 0] == "T0"
-                assert output.iloc[0, 1] == "C0"
+                assert data.iloc[0, 0] == "T0"
+                assert data.iloc[0, 1] == "C0"
             else:
-                assert valid_image_path(output)
+                assert valid_image_path(data)
 
 def test_argument_order(rbc_tiny: Path):
     # Tests that only the first unfilled argument is passed an array
@@ -92,8 +93,8 @@ def test_argument_order(rbc_tiny: Path):
             workflow = "core/tests/workflows/argument_order/test_workflow.yml",
             save_dir = tmpdir
         )
-        for roi, output in params.process_workflow().process():
-            print(output)
+        for output in params.process_workflow().process():
+            pass
 
 def test_sum_preview(rbc_tiny: Path):
     import numpy as np


### PR DESCRIPTION
Changes:

* `WorkflowSlices.process()` now yields `ProcessedWorkflowOutput`, a new class that captures various metadata such as the output index. Previously it returned a `tuple[int, DataFrame | Path]` This is a breaking change since the API has changed.
* Integrated the regions of interest to make `iter_slices()` a triple loop. This means that cropping automatically works with workflows with no extra code paths.
* Added a new `progress_bar` option to `LatticeData`, that can be used to globally disable the progress bars. This is needed to ensure the workflow progress bar works correctly

Fixes #66.