### PR TITLE
Enforce pydantic < 3

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "pyopencl",
     # This is the first pydantic version that supports the "compatibility mode"
     # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
-    "pydantic>=1.10.17",
+    "pydantic>=1.10.17,<3",
     "pyyaml",
     "read-roi",
     "rich",


### PR DESCRIPTION
Micro fix to ensure this doesn't break when pydantic 3 releases. I've now used the exact version specification they recommend on the pydantic website: https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features:~:text=pydantic%3E%3D1.10.17%2C%3C3