### PR TITLE
fix for roi indexing

### DIFF
--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -81,8 +81,7 @@ def field_from_model(model: Type[FieldAccessModel], field_name: str, extra_descr
 def handle_merge(values: list):
     if len(values) > 1:
         if all(isinstance(param, dict) for param in values):
-            merged = merge_with(handle_merge,values)
-            values = [merged]
+            return merge_with(handle_merge, values)
         else:
             raise ValueError(f"A parameter has been passed multiple times! Got: {', '.join(values)}")
     return values[0]

--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -21,6 +21,7 @@ from typer.main import get_command
 
 from lls_core.models.output import SaveFileType
 from pydantic.v1 import ValidationError
+from toolz.dicttoolz import merge_with
 
 if TYPE_CHECKING:
     from lls_core.models.utils import FieldAccessModel
@@ -79,7 +80,11 @@ def field_from_model(model: Type[FieldAccessModel], field_name: str, extra_descr
 
 def handle_merge(values: list):
     if len(values) > 1:
-        raise ValueError(f"A parameter has been passed multiple times! Got: {', '.join(values)}")
+        if all(isinstance(param, dict) for param in values):
+            merged = merge_with(handle_merge,values)
+            values = [merged]
+        else:
+            raise ValueError(f"A parameter has been passed multiple times! Got: {', '.join(values)}")
     return values[0]
 
 def rich_validation(e: ValidationError) -> Table:
@@ -224,7 +229,7 @@ def process(
     except ValidationError as e:
         console.print(rich_validation(e))
         raise Exit(code=1)
-        
+    
     lattice.save()
     console.print(f"Processing successful. Results can be found in {lattice.save_dir.resolve()}")
 

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -339,7 +339,7 @@ class LatticeData(OutputParams, DeskewParams):
         # We have an extra level of iteration for the crop path: iterating over each ROI
         for roi_index, roi in enumerate(tqdm(self.crop.selected_rois, desc="ROI", position=0)):
             # pass arguments for save tiff, callable and function arguments
-            logger.info(f"Processing ROI {roi_index}")
+            logger.info(f"Processing ROI {self.crop.roi_subset[roi_index]}")
             
             for slice in self.iter_slices():
                 deconv_args: dict[Any, Any] = {}
@@ -367,7 +367,7 @@ class LatticeData(OutputParams, DeskewParams):
                         z_end=self.crop.z_range[1],
                         **deconv_args
                     ),
-                    "roi_index": roi_index
+                    "roi_index": self.crop.roi_subset[roi_index]
                 })
                 
     def _process_non_crop(self) -> Iterable[ImageSlice]:


### PR DESCRIPTION
Fix for issue #72 

Checks if parameters are dictionaries in the case of nested parameters and calls merge_with recursively. Note I had to move the import further up.

Also fixes related(?) undocumented issue where rois are reindexed from zero regardless of roi-subset values. This caused issues with output images having the same name despite being different rois. 