### PR TITLE
Fix_dependency

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     env:
       DISPLAY: ":99.0"
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # Older tifffile are not compatible with aicsimageio, see: https://github.com/AllenCellModeling/aicsimageio/issues/518
     "napari-workflows>=0.2.8",
     "npy2bdv",
-    "numpy",
+    "numpy<2",
     "pandas",
     "pyclesperanto_prototype>=0.20.0",
     "pyopencl",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "dask[distributed]",
     "fsspec>=2022.8.2",
     "importlib_resources",
-    # Older tifffile are not compatible with aicsimageio, see: https://github.com/AllenCellModeling/aicsimageio/issues/518
     "napari-workflows>=0.2.8",
     "npy2bdv",
     "numpy<2",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "napari-spreadsheet",
     "napari-workflow-inspector",
     "napari-workflows>=0.2.8",
-    "napari[all]>=0.4.11,
+    "napari[all]>=0.4.11",
     "npy2bdv",
     "numpy<2",
     "psutil",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "napari-spreadsheet",
     "napari-workflow-inspector",
     "napari-workflows>=0.2.8",
-    "napari>=0.4.11",
+    "napari[all]>=0.4.11,
     "npy2bdv",
     "numpy<2",
     "psutil",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "magicgui<0.8.0",
     # Currently commented out to avoid installation issues, although
     # This can be reinstated once https://github.com/pypa/pip/pull/12095 is merged
-    # "napari-aicsimageio>=0.7.2",
+    "napari-aicsimageio>=0.7.2",
     "napari-spreadsheet",
     "napari-workflow-inspector",
     "napari-workflows>=0.2.8",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+    "aicsimageio>=4.6.3",
     "dask[distributed]",
     # This isn't used directly, but we need to pin this version
     "fsspec>=2022.8.2",
@@ -52,10 +53,12 @@ dependencies = [
     "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",
+    "pydantic",
     "qtpy",
     "typing_extensions>=4.7.0",
     "rich",
     "StrEnum",
+    "xarray"
 ]
 
 [project.urls]

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -46,8 +46,6 @@ dependencies = [
     # The upper bound is because we are waiting on https://github.com/hanjinliu/magic-class/issues/128
     "magic-class>=0.7.5,<0.8.0",
     "magicgui<0.8.0",
-    # Currently commented out to avoid installation issues, although
-    # This can be reinstated once https://github.com/pypa/pip/pull/12095 is merged
     "napari-aicsimageio>=0.7.2",
     "napari-spreadsheet",
     "napari-workflow-inspector",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "napari-workflows>=0.2.8",
     "napari>=0.4.11",
     "npy2bdv",
-    "numpy",
+    "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",
     "pydantic",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -36,18 +36,15 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "aicsimageio>=4.6.3",
     "dask[distributed]",
     # This isn't used directly, but we need to pin this version
     "fsspec>=2022.8.2",
     "importlib_resources",
     "lls_core",
     # The lower bound is because we need this Python 3.8 fix: https://github.com/hanjinliu/magic-class/pull/108
-    # The upper bound is because we are waiting on https://github.com/hanjinliu/magic-class/issues/128
-    "magic-class>=0.7.5,<0.8.0",
+    "magic-class>=0.7.5",
     "magicgui<0.8.0",
     "napari-aicsimageio>=0.7.2",
-    "napari-spreadsheet",
     "napari-workflow-inspector",
     "napari-workflows>=0.2.8",
     "napari[all]>=0.4.11",
@@ -55,12 +52,10 @@ dependencies = [
     "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",
-    "pydantic",
     "qtpy",
     "typing_extensions>=4.7.0",
     "rich",
     "StrEnum",
-    "xarray"
 ]
 
 [project.urls]


### PR DESCRIPTION
Modified pyproject.toml files

- added back napari-aicsimageio constraint
linked PR was merged: https://github.com/pypa/pip/pull/12095

- added napari[all] so pyqt5 is installed by default

- added numpy<2 constraint