### PR TITLE
Adding an option to apply quick deskew. Only works in 3D view

### DIFF
--- a/core/lls_core/utils.py
+++ b/core/lls_core/utils.py
@@ -76,7 +76,6 @@ def calculate_crop_bbox(shape: list, z_start: int, z_end: int) -> tuple[List[Lis
                          for x in product((x0, x1), (y0, y1), (z0, z1))]
     return crop_bounding_box, crop_shape
 
-
 def get_deskewed_shape(volume: ArrayLike,
                        angle: float,
                        voxel_size_x_in_microns: float,
@@ -161,8 +160,6 @@ def etree_to_dict(t: Element) -> dict:
     return d
 
 # block printing to console
-
-
 @contextmanager
 def suppress_stdout_stderr():
     """A context manager that redirects stdout and stderr to devnull"""
@@ -334,3 +331,14 @@ def make_filename_suffix(prefix: Optional[str] = None, roi_index: Optional[int] 
     if time is not None:
         components.append(f"T{time}")
     return "_".join(components)
+
+def convert_xyz_to_zyx_order(deskew_affine_transform:cle.AffineTransform3D):
+    """
+    Swap X and Z axes in affine transform matrix from pyclesperanto
+    swap from xyz to zyx order
+    """
+    deskew_affine_transform = deskew_affine_transform._matrix
+    # Swap X and Z axes using numpy indexing
+    xyz_to_zyx = [2, 1, 0, 3]  
+    zyx_tranform = deskew_affine_transform[xyz_to_zyx][:, xyz_to_zyx]
+    return zyx_tranform

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
     "pydantic>=1.10.17,<3",
     "pyyaml",
+    "ome-types<0.6.0",#pydantic v1 support removed from 0.6 onwards
     "read-roi",
     "rich",
     "resource-backed-dask-array>=0.1.0",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "resource-backed-dask-array>=0.1.0",
     "scikit-image",
     "StrEnum",
-    "tifffile>=2023.3.15", #>=2022.8.12
+    "tifffile>=2023.3.15,<2025.2.18", #>=2022.8.12
     "toolz",
     "tqdm",
     "typer",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
     "pydantic>=1.10.17,<3",
     "pyyaml",
-    "ome-types<0.6.0",#pydantic v1 support removed from 0.6 onwards
+    "ome-types<0.6.0",  #pydantic v1 support removed from 0.6 onwards
     "read-roi",
     "rich",
     "resource-backed-dask-array>=0.1.0",
@@ -148,7 +148,7 @@ ignore_unused = [
 
     # This is pinned but unused
     "fsspec",
-    "ome-types"
+    "ome-types",
 
     # Used for the deployment, but never imported
     "build",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -148,6 +148,7 @@ ignore_unused = [
 
     # This is pinned but unused
     "fsspec",
+    "ome-types"
 
     # Used for the deployment, but never imported
     "build",

--- a/plugin/napari_lattice/dock_widget.py
+++ b/plugin/napari_lattice/dock_widget.py
@@ -84,7 +84,7 @@ class LLSZWidget(MagicTemplate):
         Additional analysis parameters can be configured in the other tabs.&nbsp;
         When you are ready to save,&nbsp;go to Tab 5.&nbsp;
         Output to specify the output directory.&nbsp;
-        For more information,&nbsp;<a href="https://github.com/BioimageAnalysisCoreWEHI/napari_lattice/wiki">please refer to the documentation here</a>.
+        For more information,&nbsp;<a href="https://bioimageanalysiscorewehi.github.io/napari_lattice/">please refer to the documentation here</a>.
         </div>
         """.strip()), widget_type="Label")
 

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -278,7 +278,9 @@ class DeskewFields(NapariFieldGroup):
         tooltip="The axis along which to deskew",
         orientation="horizontal"
     )
-    quick_deskew = field(False, label="Quick Deskew")
+    quick_deskew = field(False).with_options(
+        label="Quick Deskew",
+        tooltip = "View the deskewed image. This does NOT generate a new image, but instead transforms\nthe current image in the viewer. Use `Preview` to generate a new image.")
     errors = field(Label).with_options(label="Errors")
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -348,6 +348,7 @@ class DeskewFields(NapariFieldGroup):
     @pixel_sizes_source.connect
     @pixel_sizes.connect
     def _quick_deskew(self):
+        image: Image
         #Apply quick deskew where image is displayed in canvas as deskewed. 
         #get value of quick deskew
         quick_deskew = self.quick_deskew.value
@@ -371,12 +372,15 @@ class DeskewFields(NapariFieldGroup):
             affine_transform = lattice.derived.deskew_affine_transform_zyx
             ndim_display = 3
         else:
-            pixels = self._get_kwargs()["physical_pixel_sizes"]
-            scale = (
-                        pixels.Z,
-                        pixels.Y,
-                        pixels.X,
-                    )
+            try: 
+                pixels = self._get_kwargs()["physical_pixel_sizes"]
+                scale = (
+                            pixels.Z,
+                            pixels.Y,
+                            pixels.X,
+                        )
+            except:
+                scale = None
             affine_transform = None
             ndim_display = 2
 

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -352,7 +352,7 @@ class DeskewFields(NapariFieldGroup):
             import numpy as np
             #CONVERT TRANSFORM INTO A COMPATIBLE ONE FOR NAPARI
             deskew_affine_transform = deskew.derived.deskew_affine_transform._matrix
-            #Get values from deskew transform to make it tompatible with napari
+            #Get values from deskew transform to make it compatible with napari
             #Convert from ZYX to XYZ
             deskew_affine_transform_converted = np.array([[deskew_affine_transform[2,2], deskew_affine_transform[2,1], deskew_affine_transform[2,0], deskew_affine_transform[2,3]],
                                                         [deskew_affine_transform[1,2], deskew_affine_transform[1,1], deskew_affine_transform[1,0], deskew_affine_transform[1,3]],
@@ -374,13 +374,18 @@ class DeskewFields(NapariFieldGroup):
             for image in self.img_layer.value:
                 image.affine = deskew_affine_transform_converted#deskew_affine_transform_converted 
                 image.scale = scale
+            #change to 3D view
+            viewer.dims.ndisplay = 3
             viewer.reset_view()
         else:
             #reset the image to original
             viewer = get_viewer()
             for image in self.img_layer.value:
                 image.affine = None
+            #change back to 2D view
+            viewer.dims.ndisplay = 2
             viewer.reset_view()
+            
     
     def _get_kwargs(self) -> DeskewKwargs:
         """

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "napari-workflows>=0.2.8",
     "napari[all]>=0.4.11",
     "npy2bdv",
+    "ome-types<0.6.0",#pydantic v1 support removed from 0.6 onwards
     "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "napari-workflows>=0.2.8",
     "napari[all]>=0.4.11",
     "npy2bdv",
-    "ome-types<0.6.0",#pydantic v1 support removed from 0.6 onwards
+    "ome-types<0.6.0",  #pydantic v1 support removed from 0.6 onwards
     "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -98,7 +98,8 @@ ignore_unused = [
 
     # This is pinned but unused
     "fsspec",
-    "imageio"
+    "imageio",
+    "ome-types"
 ]
 output_format = "human_detailed"  
 


### PR DESCRIPTION
In napari, we can use the affine_transform in `view_image` to render the image as deskewed without needing to explicitly process the image. 

For now, I've just implemented it as a checkbox

![image](https://github.com/user-attachments/assets/d0bd63cc-17c1-4e76-8951-1fc73e62cff4)


**The issue is this only works in 3D as when applying it in 2D, we get this error:**

> .conda\envs\napari-lattice\lib\site-packages\napari\layers\utils\_slice_input.py:189: UserWarning: Non-orthogonal slicing is being requested, but is not fully supported. Data is displayed without applying an out-of-slice rotation or shear component.!

[This is a known issue. ](https://forum.image.sc/t/non-orthogonal-slicing-warning-dataset-is-not-shown-at-all/69378)

Using napari-lattice, in regular 2D view with Quick Deskew ticked, the canvas is empty

![image](https://github.com/user-attachments/assets/ef7ba22c-a46a-4d57-9f87-58c7764a511c)

But, when I click 3D (highlighted by red box) we get the deskewed image in 3D. 

![image](https://github.com/user-attachments/assets/59eefbc8-4a49-4af7-8c91-ce07dbfc9e6d)

![image](https://github.com/user-attachments/assets/a3572ec0-2b63-41d7-a15f-9d4cbb9b38b5)

This is a nice way to preview the dataset after generation and even cropping. However
- interactivity can be slow due to large czi files. Also depends on read/write speed of storage
- Is adding a checkbox the best way to do this? Maybe place the checkbox somewhere else?

Just to add, this is different than `Preview Deskew` as the data is not processed and you cannot get a deskewed image to process or work with.

Pradeep

https://github.com/user-attachments/assets/a16a54f6-8a76-4556-9898-4be61b6f4cf0


