### PR TITLE
uv installer in github actions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -74,9 +74,9 @@ jobs:
           if (( $(echo "$(python --version | cut -d' ' -f2 | cut -d'.' -f1,2) > 3.8" | bc -l) )); then
                 uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
                 fi
-        #echo Pydantic version
-        # Print the Pydantic version to verify compatibility or debug issues
-        echo $(python -c "import pydantic; print(pydantic.__version__)")
+          #echo Pydantic version
+          #Print the Pydantic version to verify compatibility or debug issues
+          echo "$(python -c 'import pydantic; print(pydantic.__version__)')"
 
       - name: Lint plugin
         uses: ./.github/lint

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -74,6 +74,9 @@ jobs:
           if (( $(echo "$(python --version | cut -d' ' -f2 | cut -d'.' -f1,2) > 3.8" | bc -l) )); then
                 uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
                 fi
+        #echo Pydantic version
+        # Print the Pydantic version to verify compatibility or debug issues
+        echo $(python -c "import pydantic; print(pydantic.__version__)")
 
       - name: Lint plugin
         uses: ./.github/lint

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]#, "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     env:
       DISPLAY: ":99.0"
     steps:
@@ -71,7 +71,9 @@ jobs:
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
           uv pip install pytest-qt PyQt5
           uv pip install -e './plugin[testing]'
-          uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
+          if (( $(echo "$(python --version | cut -d' ' -f2 | cut -d'.' -f1,2) > 3.8" | bc -l) )); then
+                uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
+                fi
 
       - name: Lint plugin
         uses: ./.github/lint

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8","3.9","3.10"] #not compatible with py 3.10 and 3.12 yet
     env:
       DISPLAY: ":99.0"
     steps:
@@ -82,9 +82,7 @@ jobs:
           python: ${{ env.python }}
 
       - name: Test plugin
-        run: |
-          pip list
-          pytest -v --cov=plugin --cov-report=xml plugin
+        run: pytest -v --cov=plugin --cov-report=xml plugin
 
       - name: Coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          # Install a specific version of uv.
+          version: "0.6.17"
         
       - name: Install core
         timeout-minutes: 10
@@ -49,7 +52,7 @@ jobs:
           conda install -y pyopencl pocl
           python --version
           pip install --upgrade pip setuptools wheel
-          uv pip install --use-pep517 -e './core[testing]'
+          pip install --use-pep517 -e './core[testing]'
 
       - name: Lint core
         uses: ./.github/lint
@@ -66,7 +69,7 @@ jobs:
         timeout-minutes: 10
         run: |
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
-          pip install pytest-qt PyQt5
+          uv pip install pytest-qt PyQt5
           uv pip install -e './plugin[testing]'
           uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,11 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         python-version: ["3.8","3.9","3.10"] #not compatible with py 3.10 and 3.12 yet
-=======
-        python-version: ["3.11","3.12"] # ["3.8","3.9","3.10"]
->>>>>>> ad45cd65b2e8117481c34caaf9b04ef9e4dee072
+
     env:
       DISPLAY: ":99.0"
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -72,7 +72,7 @@ jobs:
           uv pip install pytest-qt PyQt5
           uv pip install -e './plugin[testing]'
           if (( $(echo "$(python --version | cut -d' ' -f2 | cut -d'.' -f1,2) > 3.8" | bc -l) )); then
-                uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
+                uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2" "ome-types<0.6.0"
                 fi
 
       - name: Lint plugin

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -74,9 +74,6 @@ jobs:
           if (( $(echo "$(python --version | cut -d' ' -f2 | cut -d'.' -f1,2) > 3.8" | bc -l) )); then
                 uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
                 fi
-          #echo Pydantic version
-          #Print the Pydantic version to verify compatibility or debug issues
-          echo "$(python -c 'import pydantic; print(pydantic.__version__)')"
 
       - name: Lint plugin
         uses: ./.github/lint
@@ -85,7 +82,9 @@ jobs:
           python: ${{ env.python }}
 
       - name: Test plugin
-        run: pytest -v --cov=plugin --cov-report=xml plugin
+        run: |
+          pip list
+          pytest -v --cov=plugin --cov-report=xml plugin
 
       - name: Coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8"]#, "3.9", "3.10"]
     env:
       DISPLAY: ":99.0"
     steps:
@@ -40,13 +40,16 @@ jobs:
       - name: Save conda location
         run: echo "python=$(which python)" >> "$GITHUB_ENV"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        
       - name: Install core
         timeout-minutes: 10
         run: |
           conda install -y pyopencl pocl
           python --version
           pip install --upgrade pip setuptools wheel
-          pip install --use-pep517 -e './core[testing]'
+          uv pip install --use-pep517 -e './core[testing]'
 
       - name: Lint core
         uses: ./.github/lint
@@ -64,7 +67,8 @@ jobs:
         run: |
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
           pip install pytest-qt PyQt5
-          pip install -e './plugin[testing]'
+          uv pip install -e './plugin[testing]'
+          uv pip install --upgrade aicsimageio "napari==0.5.5" "numpy<2"
 
       - name: Lint plugin
         uses: ./.github/lint

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",
-    "pydantic",
+    "pydantic>=1.10.17,<3",
     "qtpy",
     "typing_extensions>=4.7.0",
     "rich",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "numpy<2",
     "psutil",
     "pyclesperanto_prototype>=0.20.0",
-    "pydantic>=1.10.17,<3",
+    "pydantic",
     "qtpy",
     "typing_extensions>=4.7.0",
     "rich",


### PR DESCRIPTION
- Use uv for installing plugin, so test suite can resolve dependencies quickly especially for installing plugin.
   This also matches recommended install method in the docs.

- Added ome-types restriction or it throws an error in python 3.9