### PR TITLE
Zarr writer

### DIFF
--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -498,9 +498,11 @@ class LatticeData(OutputParams, DeskewParams):
         raise Exception("No slices produced!")
 
     def get_writer(self) -> Type[Writer]:
-        from lls_core.writers import BdvWriter, TiffWriter
+        from lls_core.writers import BdvWriter, TiffWriter, OMEZarrWriter
         if self.save_type == SaveFileType.h5:
             return BdvWriter
         elif self.save_type == SaveFileType.tiff:
             return TiffWriter
+        elif self.save_type == SaveFileType.omezarr:
+            return OMEZarrWriter
         raise Exception("Unknown output type")

--- a/core/lls_core/models/output.py
+++ b/core/lls_core/models/output.py
@@ -14,6 +14,7 @@ class SaveFileType(StrEnum):
     """
     h5 = "h5"
     tiff = "tiff"
+    omezarr = "omezarr"
 
 class OutputParams(FieldAccessModel):
     save_dir: DirectoryPath = Field(
@@ -59,6 +60,8 @@ class OutputParams(FieldAccessModel):
     def file_extension(self):
         if self.save_type == SaveFileType.h5:
             return "h5"
+        elif self.save_type == SaveFileType.omezarr:
+            return "ome.zarr"
         else:
             return "tif"
 

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -195,7 +195,7 @@ class OMEZarrWriter(Writer):
         c_idx = int(getattr(slice, "channel_index", 0))
         t_len, c_len = self._resolve_t_c_lengths(slice)
 
-        # If it's the first slice - initialize the full zarr array suze
+        # If it's the first slice - initialize the full zarr array size
         if self._arr is None:
             self._root_group, self._arr = self._create_store(t_len, c_len, self._zyx, self._dtype)
         

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -176,7 +176,7 @@ class OMEZarrWriter(Writer):
         self._zyx = None
         self._t_len = None
         self._c_len = None
-        self._dtype = None
+        self._dtype = np.uint16
 
         self._pix_z, self._pix_y, self._pix_x = (self.lattice.new_dz, self.lattice.dy, self.lattice.dx)
 
@@ -199,7 +199,7 @@ class OMEZarrWriter(Writer):
         if self._arr is None:
             self._root_group, self._arr = self._create_store(t_len, c_len, self._zyx, self._dtype)
         
-        self._arr[t_idx, c_idx, :, :, :] = data3d
+        self._arr[t_idx, c_idx, :, :, :] = np.clip(data3d, 0.0, 65535.0).astype(np.uint16)
         return self._root_path
 
     # Optional hook if the framework ever calls it.

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -159,7 +159,6 @@ class OMEZarrWriter(Writer):
         self.chunk_zyx = chunk_zyx
         self.compressor = compressor or Blosc(cname="zstd", clevel=5, shuffle=Blosc.SHUFFLE)
 
-        self._roi_index = roi_index
         self._roi_label = roi_label
 
         self._save_dir = Path(self.params.save_dir)

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -145,7 +145,7 @@ class OMEZarrWriter(Writer):
         params,
         *,
         overwrite: bool = True,
-        chunk_zyx: Tuple[int, int, int] = DEFAULT_CHUNK_ZYX,
+        chunk_zyx: tuple[int, int, int] = DEFAULT_CHUNK_ZYX,
         compressor: Optional[Blosc] = None,
         roi_index: Optional[int] = None,         
         roi_label: Optional[str] = None,         
@@ -207,7 +207,7 @@ class OMEZarrWriter(Writer):
         """No-op; multiscales metadata is written at creation."""
         return
 
-    def _resolve_t_c_lengths(self, slice) -> Tuple[int, int]:
+    def _resolve_t_c_lengths(self, slice) -> tuple[int, int]:
         if self._t_len is not None and self._c_len is not None:
             return self._t_len, self._c_len
         t_len = len(getattr(self.params, "time_range", None))
@@ -216,8 +216,8 @@ class OMEZarrWriter(Writer):
         return t_len, c_len
 
     def _create_store(
-        self, t_len: int, c_len: int, zyx: Tuple[int, int, int], dtype: np.dtype
-    ) -> Tuple[zarr.Group, zarr.Array]:
+        self, t_len: int, c_len: int, zyx: tuple[int, int, int], dtype: np.dtype
+    ) -> tuple[zarr.Group, zarr.Array]:
         if self.overwrite and self._root_path.exists():
             import shutil
             shutil.rmtree(self._root_path)

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -209,8 +209,8 @@ class OMEZarrWriter(Writer):
     def _resolve_t_c_lengths(self, slice) -> tuple[int, int]:
         if self._t_len is not None and self._c_len is not None:
             return self._t_len, self._c_len
-        t_len = len(getattr(self.params, "time_range", None))
-        c_len = len(getattr(self.params, "channel_range", None))     
+        t_len = len(getattr(self.params, "time_range", None) or [])
+        c_len = len(getattr(self.params, "channel_range", None) or [])
         self._t_len, self._c_len = t_len, c_len 
         return t_len, c_len
 

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -8,6 +8,13 @@ from lls_core.types import ArrayLike
 
 from pydantic.v1 import NonNegativeInt
 
+from numcodecs import Blosc
+from pathlib import Path
+import xarray as xr
+import dask.array as da
+import numpy as np
+import zarr
+
 from lls_core.utils import make_filename_suffix
 RoiIndex = Optional[NonNegativeInt]
 
@@ -116,7 +123,7 @@ class TiffWriter(Writer):
                 imagej=True
             )
             self.written_files.append(path)
-
+            
             # Reinitialise
             self.pending_slices = []
 
@@ -129,3 +136,145 @@ class TiffWriter(Writer):
 
     def close(self):
         self.flush()
+
+@dataclass
+class OMEZarrWriter(Writer):
+    DEFAULT_CHUNK_ZYX = (64, 256, 256)
+    def __init__(
+        self,
+        params,
+        *,
+        overwrite: bool = True,
+        chunk_zyx: Tuple[int, int, int] = DEFAULT_CHUNK_ZYX,
+        compressor: Optional[Blosc] = None,
+        roi_index: Optional[int] = None,         
+        roi_label: Optional[str] = None,         
+        **kwargs,                                
+    ) -> None:
+        self._roi_index = int(roi_index) if roi_index is not None else int(getattr(params, "roi_index", 0))
+
+        super().__init__(params,roi_index=self._roi_index)
+        self.params = params
+        self.overwrite = overwrite
+        self.chunk_zyx = chunk_zyx
+        self.compressor = compressor or Blosc(cname="zstd", clevel=5, shuffle=Blosc.SHUFFLE)
+
+        self._roi_index = roi_index
+        self._roi_label = roi_label
+
+        self._save_dir = Path(self.params.save_dir)
+        self._save_dir.mkdir(parents=True, exist_ok=True)
+
+        suffix = f"_{make_filename_suffix(roi_index=str(self.roi_index))}" if self.roi_index is not None else ""
+        path = self.lattice.make_filepath(suffix)
+
+        self._base_name = path.name
+        self._root_path = path
+
+        self._arr = None
+        self._root_group = None
+        self._zyx = None
+        self._t_len = None
+        self._c_len = None
+        self._dtype = None
+
+        self._pix_z, self._pix_y, self._pix_x = (self.lattice.new_dz, self.lattice.dy, self.lattice.dx)
+
+    def write_slice(self, slice) -> Path:
+        """Write a 3D (Z,Y,X) slice into (t,c,:,:,:) and return root .ome.zarr path."""
+        data3d = self._to_numpy(getattr(slice, "data", slice))
+        if data3d.ndim != 3:
+            raise ValueError(f"Expected (Z,Y,X), got {data3d.shape}")
+
+        if self._zyx is None:
+            self._zyx = (int(data3d.shape[0]), int(data3d.shape[1]), int(data3d.shape[2]))
+        if self._dtype is None:
+            self._dtype = data3d.dtype
+
+        t_idx = int(getattr(slice, "time_index", 0))
+        c_idx = int(getattr(slice, "channel_index", 0))
+        t_len, c_len = self._resolve_t_c_lengths(slice)
+
+        # If it's the first slice - initialize the full zarr array suze
+        if self._arr is None:
+            self._root_group, self._arr = self._create_store(t_len, c_len, self._zyx, self._dtype)
+        
+        self._arr[t_idx, c_idx, :, :, :] = data3d
+        return self._root_path
+
+    # Optional hook if the framework ever calls it.
+    def finalize(self) -> None:
+        """No-op; multiscales metadata is written at creation."""
+        return
+
+    def _resolve_t_c_lengths(self, slice) -> Tuple[int, int]:
+        if self._t_len is not None and self._c_len is not None:
+            return self._t_len, self._c_len
+        t_len = len(getattr(self.params, "time_range", None))
+        c_len = len(getattr(self.params, "channel_range", None))     
+        self._t_len, self._c_len = t_len, c_len 
+        return t_len, c_len
+
+    def _create_store(
+        self, t_len: int, c_len: int, zyx: Tuple[int, int, int], dtype: np.dtype
+    ) -> Tuple[zarr.Group, zarr.Array]:
+        if self.overwrite and self._root_path.exists():
+            import shutil
+            shutil.rmtree(self._root_path)
+
+        store = zarr.DirectoryStore(str(self._root_path))
+        root = zarr.group(store=store)
+
+        chunks = (1, 1, *self.chunk_zyx)
+        arr = root.create_dataset(
+            "0",
+            shape=(t_len, c_len, zyx[0], zyx[1], zyx[2]),
+            chunks=chunks,
+            compressor=self.compressor,
+            dtype=dtype,
+            overwrite=self.overwrite,
+        )
+        self._write_ngff_attrs(root)
+        return root, arr
+
+    def _write_ngff_attrs(self, group: zarr.Group) -> None:
+        # Minimal, valid NGFF (v0.4) with (t,c,z,y,x) and micrometer units
+        z_ps = float(self._pix_z)
+        y_ps = float(self._pix_y)
+        x_ps = float(self._pix_x)
+        group.attrs["multiscales"] = [
+            {
+                "version": "0.4",
+                "name": self._base_name,
+                "axes": [
+                    {"name": "t", "type": "time"},
+                    {"name": "c", "type": "channel"},
+                    {"name": "z", "type": "space", "unit": "micrometer"},
+                    {"name": "y", "type": "space", "unit": "micrometer"},
+                    {"name": "x", "type": "space", "unit": "micrometer"},
+                ],
+                "datasets": [
+                    {
+                        "path": "0",
+                        "coordinateTransformations": [
+                            {"type": "scale", "scale": [1.0, 1.0, float(z_ps), float(y_ps), float(x_ps)]}
+                        ],
+                    }
+                ],
+            }
+        ]
+        # Optional: coarse OMERO display info
+        cN = int(self._c_len or 1)
+        group.attrs["omero"] = {
+            "name": self._base_name,
+            "version": "0.4",
+            "channels": [{"label": f"C{c}"} for c in range(cN)],
+        }
+
+    @staticmethod
+    def _to_numpy(data) -> np.ndarray:
+        if isinstance(data, xr.DataArray):
+            data = data.data
+        if da is not None and isinstance(data, da.Array):
+            return np.asarray(data.compute())
+        return np.asarray(data)

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -67,6 +67,8 @@ dependencies = [
     "typer",
     "typing_extensions>=4.7.0",
     "xarray[parallel]",
+    "zarr>=2.16,<3",
+    "numcodecs>=0.11",
 ]
 
 [project.urls]


### PR DESCRIPTION
Still specifies the size of the final stack on first write - but I think this might actually be preferable as it allows simpler building but also writes the metadata correctly without having to wait for the final timepoint. 