### PR TITLE
Saving dict,pandas output from workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ dask-worker-space/
 
 # sample data folder for testing
 notebooks/sample_data/*
+notebooks/troubleshooting/sample_data/*

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -191,7 +191,7 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
                                 #Add time and channel columns that match the max length
                                 time_values = [f"T{result.time_index}"] * max_length
                                 channel_values = [f"C{result.channel_index}"] * max_length
-                            else:
+                            else: #handles empty dict
                                 time_values = f"T{result.time_index}"
                                 channel_values = f"C{result.channel_index}"
                                 

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -185,8 +185,11 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
                         if isinstance(element, dict):
                             # If the row is a dict, it has column names
                             #get max length of values in element
-                            len_values = {k:len(v) for k,v in element.items()}
-                            max_length = max(len_values.values())
+                            len_values = {k: len(v) if isinstance(v, Iterable) and not isinstance(v, str) else 1 for k, v in element.items()}
+                            if len_values:
+                                max_length = max(len_values.values())
+                            else:
+                                max_length = 1
                             #Add time and channel columns that match the max length
                             time_values = [f"T{result.time_index}"] * max_length
                             channel_values = [f"C{result.channel_index}"] * max_length

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -188,11 +188,13 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
                             len_values = {k: len(v) if isinstance(v, Iterable) and not isinstance(v, str) else 1 for k, v in element.items()}
                             if len_values:
                                 max_length = max(len_values.values())
+                                #Add time and channel columns that match the max length
+                                time_values = [f"T{result.time_index}"] * max_length
+                                channel_values = [f"C{result.channel_index}"] * max_length
                             else:
-                                max_length = 1
-                            #Add time and channel columns that match the max length
-                            time_values = [f"T{result.time_index}"] * max_length
-                            channel_values = [f"C{result.channel_index}"] * max_length
+                                time_values = f"T{result.time_index}"
+                                channel_values = f"C{result.channel_index}"
+                                
                             element = {"time": time_values, "channel": channel_values, **element}
                             
                         elif isinstance(element, DataFrame):

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -184,7 +184,19 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
 
                         if isinstance(element, dict):
                             # If the row is a dict, it has column names
-                            element = {"time": f"T{result.time_index}", "channel": f"C{result.channel_index}", **element}
+                            #get max length of values in element
+                            len_values = {k:len(v) for k,v in element.items()}
+                            max_length = max(len_values.values())
+                            #Add time and channel columns that match the max length
+                            time_values = [f"T{result.time_index}"] * max_length
+                            channel_values = [f"C{result.channel_index}"] * max_length
+                            element = {"time": time_values, "channel": channel_values, **element}
+                        elif isinstance(element, pd.DataFrame):
+                            #add time and channel columns
+                            element["time"] = f"T{result.time_index}"
+                            element["channel"] = f"C{result.channel_index}"
+                            #convert to dict
+                            element = element.to_dict(orient="series")
                         elif isinstance(element, Iterable):
                             # If the row is a list, it has no column names
                             # We add the channel and time 

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -194,12 +194,20 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
                             time_values = [f"T{result.time_index}"] * max_length
                             channel_values = [f"C{result.channel_index}"] * max_length
                             element = {"time": time_values, "channel": channel_values, **element}
-                        elif isinstance(element, pd.DataFrame):
+                            
+                        elif isinstance(element, DataFrame):
                             #add time and channel columns
-                            element["time"] = f"T{result.time_index}"
-                            element["channel"] = f"C{result.channel_index}"
+                            element.insert(0, "time", f"T{result.time_index}")
+                            element.insert(1, "channel", f"C{result.channel_index}")
+                            print(f"Added Time T{result.time_index} and Channel C{result.channel_index} columns")
                             #convert to dict
-                            element = element.to_dict(orient="series")
+                            records = element.to_dict(orient="records")
+
+                            # Add each record as a separate row
+                            rows.extend(records)
+
+                            continue #skips rows.append and continues to next iteration
+
                         elif isinstance(element, Iterable):
                             # If the row is a list, it has no column names
                             # We add the channel and time 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "tifffile>=2023.3.15,<2025.2.18", #>=2022.8.12
     "toolz",
     "tqdm",
-    "typer",
+    "typer<0.17.0",
     "typing_extensions>=4.7.0",
     "xarray[parallel]",
 ]

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -72,7 +72,7 @@ def image_workflow() -> Workflow:
 
 @pytest.fixture
 def table_workflow(image_workflow: Workflow) -> Workflow:
-    # Complex workflow that returns a tuple of (image, dict, list, int)
+    # Complex workflow that returns a tuple of (image, dict, dict with multiple values, list, int)
     ret = copy(image_workflow)
     ret.set("result", lambda x: (
         x,
@@ -80,6 +80,7 @@ def table_workflow(image_workflow: Workflow) -> Workflow:
             "foo": 1,
             "bar": 2
         },
+        {'multi1': [1, 2, 3], 'multi2': ['a', 'b', 'c']},
         ["foo", "bar"],
         1
     ), "labeling")

--- a/core/tests/test_process.py
+++ b/core/tests/test_process.py
@@ -146,7 +146,7 @@ def test_table_workflow(
             }
         ).process_workflow().save())
         # There should be one output for each element of the tuple
-        assert {result.name for result in results} == {'LLS7_t1_ch1_deskewed_output_3.csv', 'LLS7_t1_ch1_deskewed.h5', 'LLS7_t1_ch1_deskewed_output_1.csv', 'LLS7_t1_ch1_deskewed_output_2.csv'}
+        assert {result.name for result in results} == {'LLS7_t1_ch1_deskewed_output_3.csv', 'LLS7_t1_ch1_deskewed.h5', 'LLS7_t1_ch1_deskewed_output_1.csv', 'LLS7_t1_ch1_deskewed_output_2.csv','LLS7_t1_ch1_deskewed_output_4.csv'}
 
 @pytest.mark.parametrize(
     ["roi_subset"],
@@ -200,9 +200,9 @@ def test_process_crop_workflow(table_workflow: Workflow):
         # There should be one H5 for each ROI
         image_results = [path for path in results if path.suffix == ".h5"]
         assert len(image_results) == 2
-        # There should be three CSVs for each ROI, one for each workflow result
+        # There should be 4 CSVs for each ROI, one for each workflow result
         csv_results = [path for path in results if path.suffix == ".csv"]
-        assert len(csv_results) == 2 * 3
+        assert len(csv_results) == 2 * 4
         for csv in csv_results:
             # Test for CSV validity
             pd.read_csv(csv)

--- a/core/tests/test_workflows.py
+++ b/core/tests/test_workflows.py
@@ -82,8 +82,15 @@ def test_table_workflow(lls7_t1_ch1: Path, table_workflow: Workflow):
                 assert nrow == params.nslices
                 assert ncol > 0
                 # Check that time and channel are included
-                assert data.iloc[0, 0] == "T0"
-                assert data.iloc[0, 1] == "C0"
+                # Accepts T0 as first element or a list of T0s. Same for C0
+                assert (
+                        data.iloc[0, 0] == "T0"
+                        or (isinstance(data.iloc[0, 0], list) and all(x == "T0" for x in data.iloc[0, 0]))
+                    )
+                assert (
+                    data.iloc[0, 1] == "C0"
+                    or (isinstance(data.iloc[0, 1], list) and all(x == "C0" for x in data.iloc[0, 1]))
+                )
             else:
                 assert valid_image_path(data)
 

--- a/notebooks/troubleshooting/troubleshooting_workflows.ipynb
+++ b/notebooks/troubleshooting/troubleshooting_workflows.ipynb
@@ -1,0 +1,691 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  Treoubleshooting workflows\n",
+    "\n",
+    "This is similar to the advanced notebook on using workflows but shows how to access workflow outputs in napari-lattice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Pradeep\\.conda\\envs\\napari-lattice\\lib\\site-packages\\pydantic\\_migration.py:283: UserWarning: `pydantic.error_wrappers:ValidationError` has been moved to `pydantic:ValidationError`.\n",
+      "  warnings.warn(f'`{import_path}` has been moved to `{new_location}`.')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<NVIDIA GeForce RTX 3080 on Platform: NVIDIA CUDA (1 refs)>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import pyclesperanto_prototype as cle\n",
+    "from napari_workflows import Workflow\n",
+    "from napari_workflows import _io_yaml_v1 as io_yaml\n",
+    "from lls_core import LatticeData\n",
+    "import numpy as np\n",
+    "import pandas as pd \n",
+    "\n",
+    "cle.get_device()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File already exists at : ./sample_data/RBC_tiny.czi\n"
+     ]
+    }
+   ],
+   "source": [
+    "#download sample data from https://zenodo.org/records/14903188\n",
+    "img_path = \"./sample_data/RBC_tiny.czi\"\n",
+    "\n",
+    "#make dir if not exists\n",
+    "if not os.path.exists(\"./sample_data\"):\n",
+    "    os.makedirs(\"./sample_data\")\n",
+    "\n",
+    "import urllib.request\n",
+    "\n",
+    "url = \"https://zenodo.org/records/14903188/files/RBC_tiny.czi?download=1\"\n",
+    "if not os.path.exists(img_path):\n",
+    "    print(\"Downloading file\")\n",
+    "    urllib.request.urlretrieve(url, img_path)\n",
+    "    print(f\"Downloaded at : {img_path}\")\n",
+    "else:\n",
+    "    print(f\"File already exists at : {img_path}\")\n",
+    "    \n",
+    "#absolute path for saving\n",
+    "#get current path\n",
+    "cur_dir = os.getcwd()\n",
+    "save_path = os.path.join(cur_dir, \"output\")\n",
+    "\n",
+    "#make dir if not exists\n",
+    "if not os.path.exists(save_path):\n",
+    "    os.makedirs(save_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have a test workflow, which applies: \n",
+    "- gaussian\n",
+    "- binarisation\n",
+    "- labeling\n",
+    "\n",
+    "\n",
+    "We would like to save the deskewed image, segmented image and the measurements as a csv file, so we return all 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Workflow:\n",
+      "gaussian <- (<function gaussian_blur at 0x000002D8D2D1CA60>, 'deskewed_image', None, 1, 1, 1)\n",
+      "binarisation <- (<function greater_constant at 0x000002D8D2D1D360>, 'gaussian', None, 0.5)\n",
+      "labeling <- (<function connected_components_labeling_box at 0x000002D8D2E05CF0>, 'binarisation')\n",
+      "result <- (<function measure_region at 0x000002D8A449EDD0>, 'deskewed_image', 'labeling')\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def image_workflow() -> Workflow:\n",
+    "    # Simple segmentation workflow that returns an image\n",
+    "    image_seg_workflow = Workflow()\n",
+    "    image_seg_workflow.set(\"gaussian\", cle.gaussian_blur, \"deskewed_image\", sigma_x=1, sigma_y=1, sigma_z=1)\n",
+    "    image_seg_workflow.set(\"binarisation\", cle.threshold, \"gaussian\", constant=0.5)\n",
+    "    image_seg_workflow.set(\"labeling\", cle.connected_components_labeling_box, \"binarisation\")\n",
+    "    image_seg_workflow.set(\"result\",measure_region,\"deskewed_image\",\"labeling\")\n",
+    "    return image_seg_workflow\n",
+    "\n",
+    "def measure_region(image,label) -> dict:\n",
+    "    # Measure properties of the segmented regions\n",
+    "    from skimage.measure import regionprops_table\n",
+    "    #convert to numpy\n",
+    "    image = np.asarray(image)\n",
+    "    label = np.asarray(label)\n",
+    "    props = regionprops_table(label, image,\n",
+    "                              properties=['label', 'bbox','area', \n",
+    "                                          'intensity_mean'])\n",
+    "    return props\n",
+    "\n",
+    "image_analysis_workflow = image_workflow()\n",
+    "\n",
+    "print(image_analysis_workflow)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO:2025-09-02 14:51:29,318] Processing File ./sample_data/RBC_tiny.czi\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "LatticeData(input_image=<xarray.DataArray 'transpose-aa2bd2dc5da500b61f8f6aa8fdb114ba' (T: 1, C: 1,\n",
+       "                                                                Z: 834, Y: 118,\n",
+       "                                                                X: 209)>\n",
+       "dask.array<transpose, shape=(1, 1, 834, 118, 209), dtype=uint16, chunksize=(1, 1, 834, 118, 209), chunktype=numpy.ndarray>\n",
+       "Coordinates:\n",
+       "  * C        (C) <U17 'LatticeLightsheet'\n",
+       "  * Z        (Z) float64 0.0 0.3 0.6 0.9 1.2 ... 248.7 249.0 249.3 249.6 249.9\n",
+       "  * Y        (Y) float64 0.0 0.145 0.29 0.435 0.58 ... 16.53 16.67 16.82 16.96\n",
+       "  * X        (X) float64 0.0 0.145 0.29 0.435 0.58 ... 29.72 29.87 30.01 30.16\n",
+       "Dimensions without coordinates: T\n",
+       "Attributes:\n",
+       "    unprocessed:  <Element 'ImageDocument' at 0x000002D8892E6B10>, skew=<DeskewDirection.Y: 2>, angle=30.0, physical_pixel_sizes=DefinedPixelSizes(X=0.14499219272808386, Y=0.14499219272808386, Z=0.3), derived=DerivedDeskewFields(deskew_vol_shape=(59, 1828, 209), deskew_affine_transform=<pyclesperanto_prototype._tier8._AffineTransform3D.AffineTransform3D object at 0x000002D88D71BFA0>, deskew_affine_transform_zyx=array([[ 6.01508636e-17, -5.00000000e-01,  0.00000000e+00,\n",
+       "         5.90000000e+01],\n",
+       "       [ 2.06907692e+00,  8.66025404e-01,  0.00000000e+00,\n",
+       "         0.00000000e+00],\n",
+       "       [ 0.00000000e+00,  0.00000000e+00,  1.00000000e+00,\n",
+       "         0.00000000e+00],\n",
+       "       [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,\n",
+       "         1.00000000e+00]])), save_dir=WindowsPath('c:/Users/Pradeep/nap/napari_lattice/notebooks/troubleshooting/output'), save_suffix='_deskewed', save_name='RBC_tiny_deskewed', save_type=<SaveFileType.h5: 'h5'>, time_range=range(0, 1), channel_range=range(0, 1), deconvolution=None, crop=None, workflow=<napari_workflows._workflow.Workflow object at 0x000002D8892AB790>, progress_bar=True)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params_workflow = LatticeData(\n",
+    "  input_image=img_path,\n",
+    "  save_dir=save_path,\n",
+    "  workflow=image_analysis_workflow,\n",
+    ")\n",
+    "params_workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Troubleshooting\n",
+    "\n",
+    "To inspect the components of workflows, you can use 2 approaches:\n",
+    "- `process_workflow` to access the output from the workflow\n",
+    "- `process_workflow().process()` to access the workflow output after metadata, such as time and channel has been added to it. \n",
+    "\n",
+    "`process_workflow`: It returns a generator object, which can be accessed using the `next` function\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('slices',\n",
+       " <generator object LatticeData.process_workflow.<locals>._generator at 0x000002D88929D540>)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for slice in params_workflow.process_workflow():\n",
+    "    first_slice = slice\n",
+    "    break\n",
+    "first_slice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Timepoints:   0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO:2025-09-02 14:51:29,827] Processing File <xarray.DataArray 'transpose-aa2bd2dc5da500b61f8f6aa8fdb114ba' (Z: 834, Y: 118,\n",
+      "                                                                X: 209)>\n",
+      "dask.array<getitem, shape=(834, 118, 209), dtype=uint16, chunksize=(834, 118, 209), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "    C        <U17 'LatticeLightsheet'\n",
+      "  * Z        (Z) float64 0.0 0.3 0.6 0.9 1.2 ... 248.7 249.0 249.3 249.6 249.9\n",
+      "  * Y        (Y) float64 0.0 0.145 0.29 0.435 0.58 ... 16.53 16.67 16.82 16.96\n",
+      "  * X        (X) float64 0.0 0.145 0.29 0.435 0.58 ... 29.72 29.87 30.01 30.16\n",
+      "Attributes:\n",
+      "    unprocessed:  <Element 'ImageDocument' at 0x000002D8892E6B10>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_set = next(first_slice[1])\n",
+    "print(len(data_set.data)) #1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({'label': array([1]),\n",
+       "  'bbox-0': array([0]),\n",
+       "  'bbox-1': array([0]),\n",
+       "  'bbox-2': array([0]),\n",
+       "  'bbox-3': array([59]),\n",
+       "  'bbox-4': array([1827]),\n",
+       "  'bbox-5': array([209]),\n",
+       "  'area': array([21393187.]),\n",
+       "  'intensity_mean': array([321.0536499])},)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_set.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "label",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-0",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-1",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-2",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-3",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-4",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-5",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "area",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "intensity_mean",
+         "rawType": "object",
+         "type": "unknown"
+        }
+       ],
+       "ref": "267d2bc6-ed0d-4b3b-9247-cad5cc551332",
+       "rows": [
+        [
+         "0",
+         "[1]",
+         "[0]",
+         "[0]",
+         "[0]",
+         "[59]",
+         "[1827]",
+         "[209]",
+         "[21393187.]",
+         "[321.0536499]"
+        ]
+       ],
+       "shape": {
+        "columns": 9,
+        "rows": 1
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>label</th>\n",
+       "      <th>bbox-0</th>\n",
+       "      <th>bbox-1</th>\n",
+       "      <th>bbox-2</th>\n",
+       "      <th>bbox-3</th>\n",
+       "      <th>bbox-4</th>\n",
+       "      <th>bbox-5</th>\n",
+       "      <th>area</th>\n",
+       "      <th>intensity_mean</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>[1]</td>\n",
+       "      <td>[0]</td>\n",
+       "      <td>[0]</td>\n",
+       "      <td>[0]</td>\n",
+       "      <td>[59]</td>\n",
+       "      <td>[1827]</td>\n",
+       "      <td>[209]</td>\n",
+       "      <td>[21393187.0]</td>\n",
+       "      <td>[321.05364990234375]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  label bbox-0 bbox-1 bbox-2 bbox-3  bbox-4 bbox-5          area  \\\n",
+       "0   [1]    [0]    [0]    [0]   [59]  [1827]  [209]  [21393187.0]   \n",
+       "\n",
+       "         intensity_mean  \n",
+       "0  [321.05364990234375]  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(data_set.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Timepoints:   0%|          | 0/1 [00:00<?, ?it/s][INFO:2025-09-02 14:51:40,603] Processing File <xarray.DataArray 'transpose-aa2bd2dc5da500b61f8f6aa8fdb114ba' (Z: 834, Y: 118,\n",
+      "                                                                X: 209)>\n",
+      "dask.array<getitem, shape=(834, 118, 209), dtype=uint16, chunksize=(834, 118, 209), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "    C        <U17 'LatticeLightsheet'\n",
+      "  * Z        (Z) float64 0.0 0.3 0.6 0.9 1.2 ... 248.7 249.0 249.3 249.6 249.9\n",
+      "  * Y        (Y) float64 0.0 0.145 0.29 0.435 0.58 ... 16.53 16.67 16.82 16.96\n",
+      "  * X        (X) float64 0.0 0.145 0.29 0.435 0.58 ... 29.72 29.87 30.01 30.16\n",
+      "Attributes:\n",
+      "    unprocessed:  <Element 'ImageDocument' at 0x000002D8892E6B10>\n",
+      "[INFO:2025-09-02 14:51:40,603] Processing File <xarray.DataArray 'transpose-aa2bd2dc5da500b61f8f6aa8fdb114ba' (Z: 834, Y: 118,\n",
+      "                                                                X: 209)>\n",
+      "dask.array<getitem, shape=(834, 118, 209), dtype=uint16, chunksize=(834, 118, 209), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "    C        <U17 'LatticeLightsheet'\n",
+      "  * Z        (Z) float64 0.0 0.3 0.6 0.9 1.2 ... 248.7 249.0 249.3 249.6 249.9\n",
+      "  * Y        (Y) float64 0.0 0.145 0.29 0.435 0.58 ... 16.53 16.67 16.82 16.96\n",
+      "  * X        (X) float64 0.0 0.145 0.29 0.435 0.58 ... 29.72 29.87 30.01 30.16\n",
+      "Attributes:\n",
+      "    unprocessed:  <Element 'ImageDocument' at 0x000002D8892E6B10>\n",
+      "Timepoints: 100%|██████████| 1/1 [00:04<00:00,  4.14s/it]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[   time channel label bbox-0 bbox-1 bbox-2 bbox-3  bbox-4 bbox-5  \\\n",
+       " 0  [T0]    [C0]   [1]    [0]    [0]    [0]   [59]  [1827]  [209]   \n",
+       " \n",
+       "            area        intensity_mean  \n",
+       " 0  [21393187.0]  [321.05364990234375]  ]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outputs = []\n",
+    "for output in params_workflow.process_workflow().process():\n",
+    "    data = output.data\n",
+    "    outputs.append(data)\n",
+    "outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "time",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "channel",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "label",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-0",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-1",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-2",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-3",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-4",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "bbox-5",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "area",
+         "rawType": "object",
+         "type": "unknown"
+        },
+        {
+         "name": "intensity_mean",
+         "rawType": "object",
+         "type": "unknown"
+        }
+       ],
+       "ref": "edfcb4fd-2b74-4719-bef2-317ae5da4b0b",
+       "rows": [
+        [
+         "0",
+         "T0",
+         "C0",
+         "1",
+         "0",
+         "0",
+         "0",
+         "59",
+         "1827",
+         "209",
+         "21393187.0",
+         "321.05364990234375"
+        ]
+       ],
+       "shape": {
+        "columns": 11,
+        "rows": 1
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>channel</th>\n",
+       "      <th>label</th>\n",
+       "      <th>bbox-0</th>\n",
+       "      <th>bbox-1</th>\n",
+       "      <th>bbox-2</th>\n",
+       "      <th>bbox-3</th>\n",
+       "      <th>bbox-4</th>\n",
+       "      <th>bbox-5</th>\n",
+       "      <th>area</th>\n",
+       "      <th>intensity_mean</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>T0</td>\n",
+       "      <td>C0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>59</td>\n",
+       "      <td>1827</td>\n",
+       "      <td>209</td>\n",
+       "      <td>21393187.0</td>\n",
+       "      <td>321.05365</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  time channel label bbox-0 bbox-1 bbox-2 bbox-3 bbox-4 bbox-5        area  \\\n",
+       "0   T0      C0     1      0      0      0     59   1827    209  21393187.0   \n",
+       "\n",
+       "  intensity_mean  \n",
+       "0      321.05365  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outputs[0].apply(pd.Series.explode)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "napari-lattice",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Updates the `process` method in `core/lls_core/models/results.py` to improve how time and channel metadata are added to processed workflow outputs. 
Ensure that these metadata columns match the length of the data, and also add support for handling pandas dataframe elements. 

**Enhancements to metadata handling:**

* When an element is a `dict`, time and channel columns are now lists matching the maximum length of the dict's values, rather than single values.
* Added support for elements that are `pandas.DataFrame` objects: time and channel columns are added, and the dataframe is converted to a dict with series orientation.