### PR TITLE
Fix bug with range parsing logic from gui

### DIFF
--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -156,7 +156,7 @@ class LatticeData(OutputParams, DeskewParams):
             default_end = values["input_image"].sizes["T"]
             if v is None:
                 return range(default_start, default_end)
-            elif isinstance(v, Sequence) and len(v) == 2:
+            elif not isinstance(v, range) and isinstance(v, Sequence) and len(v) == 2:
                 # Allow 2-tuples to be used as input for this field
                 return range(v[0] or default_start, v[1] or default_end)
         return v
@@ -174,7 +174,7 @@ class LatticeData(OutputParams, DeskewParams):
             default_end = values["input_image"].sizes["C"]
             if v is None:
                 return range(default_start, default_end)
-            elif isinstance(v, Sequence) and len(v) == 2:
+            elif not isinstance(v, range) and isinstance(v, Sequence) and len(v) == 2:
                 # Allow 2-tuples to be used as input for this field
                 return range(v[0] or default_start, v[1] or default_end)
         return v


### PR DESCRIPTION
Fix range parsing logic in the `lattice_data.py` model. 
With the update: when parsing time and channel range, the code will not re-parse values that are already `range` objects.

Parsing logic improvements:

* Updated `parse_time_range` and `parse_channel_range` so that input img is not already a `range` before converting to a 2-tuple or sequence to a `range`, preventing unnecessary or incorrect conversions.

Thanks @jni