### PR TITLE
Feature/deskew tile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ dask-worker-space/
 # sample data folder for testing
 notebooks/sample_data/*
 notebooks/troubleshooting/sample_data/*
+CLAUDE.md
+.claude/settings.local.json

--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -168,12 +168,45 @@ def process(
     json_config: Optional[Path] = Option(None, show_default=False, help="Path to a JSON file from which parameters will be read."),
     yaml_config: Optional[Path] = Option(None, show_default=False, help="Path to a YAML file from which parameters will be read."),
 
+    device: Optional[str] = Option(None, help="OpenCL device to use for GPU processing. Substring match, e.g. 'RTX' or 'Intel'. Use 'list' to show available devices and exit."),
+
     show_schema: bool = Option(default=False, help="If provided, image processing will not be performed, and instead a JSON document outlining the JSON/YAML options will be printed to stdout. This can be used to assist with writing a config file for use with the --json-config and --yaml-config options.")
 ) -> None:
     from click.core import ParameterSource
     from rich.console import Console
+    import pyclesperanto_prototype as cle
+    import logging
+
+    # Show INFO-level messages from lls_core so tiling/GPU info is visible
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("lls_core").setLevel(logging.INFO)
 
     console = Console(stderr=True)
+
+    # Handle --device before anything else
+    if device is not None:
+        if device.lower() == "list":
+            console.print("[bold]Available OpenCL devices:[/bold]")
+            for name in cle.available_device_names():
+                marker = " [green](selected)[/green]" if name == cle.get_device().name else ""
+                console.print(f"  - {name}{marker}")
+            raise Exit()
+        cle.select_device(device)
+        console.print(f"Using device: {cle.get_device().name}")
+    else:
+        # Warn if there are other GPU devices available that aren't selected
+        selected = cle.get_device().name
+        other_gpus = [
+            name for name in cle.available_device_names()
+            if name != selected and "cpu" not in name.lower()
+        ]
+        if other_gpus:
+            console.print(
+                f"[yellow]Warning:[/yellow] Using [bold]{selected}[/bold], "
+                f"but other GPU(s) detected: {', '.join(other_gpus)}. "
+                f"Use [bold]--device[/bold] to select a different device "
+                f"(or [bold]--device list[/bold] to see all)."
+            )
 
     if show_schema:
         import json

--- a/core/lls_core/llsz_core.py
+++ b/core/lls_core/llsz_core.py
@@ -11,6 +11,7 @@ from pyclesperanto_prototype._tier8._affine_transform_deskew_3d import (
     affine_transform_deskew_3d,
 )
 from numpy.typing import NDArray
+import math
  
 from lls_core.utils import calculate_crop_bbox
 from lls_core import config, DeskewDirection
@@ -49,6 +50,7 @@ class CommonArgs(TypedDict, total=False):
     psf: Union[Psf, None]
     num_iter: int
     linear_interpolation: bool
+    background: Union[float, str]
     skew_dir: DeskewDirection
 
 @overload
@@ -76,6 +78,7 @@ def crop_volume_deskew(
     psf: Union[Psf, None]=None,
     num_iter: int = 10,
     linear_interpolation: bool=True,
+    background: Union[float, str] = 0,
     skew_dir: DeskewDirection=DeskewDirection.Y,
     get_deskew_and_decon: bool = False,
 ):
@@ -96,6 +99,7 @@ def crop_volume_deskew(
         psf (_type_, optional): Pass a psf array for deconvolution. Defaults to None.
         num_iter (int, optional): Number of Iterations for Richardson Lucy deconvolution. Defaults to 10.
         linear_interpolation (bool, optional): Linear Interpolation after deskewing. Defaults to True.
+        background (float, str, optional): Background value to subtract for deconvolution. Defaults to 0.
         skew_direct (DeskewDirection, optional): Deskew direction. Defaults to DeskewDirection.Y.
         get_deskew_no_decon (bool, optional): Return both deconvolved data and deskewed data with no deconvolution. Defaults to False.
 
@@ -223,6 +227,7 @@ def crop_volume_deskew(
                 dxpsf=voxel_size_x,
                 num_iter=num_iter,
                 cropping=True,
+                background=background,
             )
         else:
             crop_volume_processed = skimage_decon(
@@ -535,3 +540,468 @@ def _yield_arr_slice(img):
 
     for slice in img:
         yield slice
+
+
+def _fit_to_shape(result: NDArray, expected_shape: Tuple[int, ...]) -> NDArray:
+    """
+    Pad or crop `result` so its shape matches `expected_shape`.
+
+    This handles the edge-of-volume case where `crop_volume_deskew` may
+    return a slightly different shape than requested.
+    """
+    if result.shape == expected_shape:
+        return result
+    output = np.zeros(expected_shape, dtype=result.dtype)
+    slicers = tuple(
+        slice(0, min(result.shape[i], expected_shape[i]))
+        for i in range(result.ndim)
+    )
+    output[slicers] = result[slicers]
+    return output
+
+
+def _cast_dtype(data: NDArray, target: np.dtype) -> NDArray:
+    """Clip (for integers) and cast `data` to `target` dtype."""
+    if data.dtype == target:
+        return data
+    if np.issubdtype(target, np.integer):
+        iinfo = np.iinfo(target)
+        np.clip(data, float(iinfo.min), float(iinfo.max), out=data)
+    return data.astype(target)
+
+
+def _write_xy_tile(output: NDArray, y_start: int, x_start: int, tile: NDArray) -> None:
+    """Write a non-overlapping XY tile (full Z) into the output array."""
+    y_end = y_start + tile.shape[1]
+    x_end = x_start + tile.shape[2]
+    output[:tile.shape[0], y_start:y_end, x_start:x_end] = tile
+
+
+def deskew_xy_tiles(
+    input_volume: NDArray,
+    deskew_vol_shape: Tuple[int, ...],
+    angle_in_degrees: float,
+    voxel_size_x: float,
+    voxel_size_y: float,
+    voxel_size_z: float,
+    skew_dir: DeskewDirection,
+    output_dtype: Any = None,
+) -> NDArray:
+    """Deskew a volume by tiling in XY only, keeping the full Z per tile.
+
+    Each tile will call ``crop_volume_deskew`` with z_start=0, z_end=oz and a
+    small YX ROI.  This avoids Z-boundary artifacts caused by the deskew
+    shear. Tile writing of tile N will overlap with GPU procesing of tile N+1 GPU using a background thread.
+    This will make it faster.
+
+    Args:
+        input_volume: 3D numpy array (ZYX), already in memory.
+        deskew_vol_shape: Expected shape of the full deskewed output (Z, Y, X).
+        angle_in_degrees: Deskewing angle.
+        voxel_size_x, voxel_size_y, voxel_size_z: Pixel sizes in microns.
+        skew_dir: Deskew direction (DeskewDirection.Y or DeskewDirection.X).
+        output_dtype: If set, convert the output to this dtype.
+
+    Returns:
+        NDArray: Deskewed volume in output_dtype (or float32 if not specified).
+    """
+    #TODO: What if input volume is large on Z and does not fit; Perhaps we'll need to tile in XYZ then
+    from concurrent.futures import ThreadPoolExecutor
+    import tempfile as _tempfile
+    import os as _os
+
+    oz, oy, ox = deskew_vol_shape
+    target = np.dtype(output_dtype) if output_dtype is not None else np.dtype(np.float32)
+
+    tile_y, tile_x = get_xy_tile_sizes(
+        input_volume.shape, deskew_vol_shape, skew_dir
+    )
+
+    n_tiles_y = math.ceil(oy / tile_y)
+    n_tiles_x = math.ceil(ox / tile_x)
+
+    # Overlap margin on the shear axis — only when there are multiple tiles
+    if skew_dir == DeskewDirection.Y:
+        y_margin = _compute_overlap_margin(tile_y) if n_tiles_y > 1 else 0
+        x_margin = 0
+    else:
+        y_margin = 0
+        x_margin = _compute_overlap_margin(tile_x) if n_tiles_x > 1 else 0
+    logger.info(
+        f"XY tiling: {n_tiles_y}x{n_tiles_x} tiles of ({oz}, {tile_y}, {tile_x}), "
+        f"Y margin={y_margin}, X margin={x_margin}"
+    )
+
+    # Allocate output (memmap for >2 GB, ndarray otherwise)
+    _memmap_path = None
+    output_bytes = math.prod(deskew_vol_shape) * target.itemsize
+    if output_bytes > 2 * 1024**3:
+        _tmpfd, _memmap_path = _tempfile.mkstemp(suffix='.mmap')
+        _os.close(_tmpfd)
+        output = np.memmap(
+            _memmap_path, dtype=target, mode='w+', shape=deskew_vol_shape
+        )
+        logger.info(
+            f"Using memory-mapped output ({output_bytes / 1e9:.1f} GB, {target})"
+        )
+    else:
+        output = np.zeros(deskew_vol_shape, dtype=target)
+
+    # Pipeline: GPU on main thread, write on background thread
+    prev_future = None
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        for yi in range(0, oy, tile_y):
+            for xi in range(0, ox, tile_x):
+                y_start = yi
+                y_end = min(yi + tile_y, oy)
+                x_start = xi
+                x_end = min(xi + tile_x, ox)
+
+                # Wait for previous write before submitting the next GPU result
+                if prev_future is not None:
+                    prev_future.result()
+
+                # Expand shear axis by margin
+                y_start_exp = max(0, y_start - y_margin)
+                y_end_exp = min(oy, y_end + y_margin)
+                x_start_exp = max(0, x_start - x_margin)
+                x_end_exp = min(ox, x_end + x_margin)
+
+                roi_shape = [
+                    [y_start_exp, x_start_exp],
+                    [y_start_exp, x_end_exp],
+                    [y_end_exp, x_end_exp],
+                    [y_end_exp, x_start_exp],
+                ]
+
+                result = crop_volume_deskew(
+                    original_volume=input_volume,
+                    roi_shape=roi_shape,
+                    z_start=0,
+                    z_end=oz,
+                    angle_in_degrees=angle_in_degrees,
+                    voxel_size_x=voxel_size_x,
+                    voxel_size_y=voxel_size_y,
+                    voxel_size_z=voxel_size_z,
+                    skew_dir=skew_dir,
+                    deconvolution=False,
+                )
+
+                # Fit to expanded shape, then trim margins
+                expanded_shape = (oz, y_end_exp - y_start_exp, x_end_exp - x_start_exp)
+                result = _fit_to_shape(result, expanded_shape)
+
+                y_trim = y_start - y_start_exp
+                x_trim = x_start - x_start_exp
+                result = result[
+                    :,
+                    y_trim : y_trim + (y_end - y_start),
+                    x_trim : x_trim + (x_end - x_start),
+                ]
+
+                result = _cast_dtype(result, target)
+                prev_future = pool.submit(
+                    _write_xy_tile, output, y_start, x_start, result
+                )
+
+        if prev_future is not None:
+            prev_future.result()
+
+    if _memmap_path is not None:
+        output.flush()
+        # Copy to a regular numpy array and clean up the temp file.
+        # The memmap was only needed during tiling to avoid holding
+        # the full output + GPU buffers in RAM simultaneously.
+        result = np.array(output)
+        del output
+        try:
+            _os.unlink(_memmap_path)
+            logger.info(f"Cleaned up memmap temp file: {_memmap_path}")
+        except OSError:
+            logger.warning(f"Could not remove memmap temp file: {_memmap_path}")
+        return result
+
+    return output
+
+
+def _should_tile_on_gpu(input_shape, output_shape: Tuple[int, ...], dtype: Any) -> bool:
+    """
+    Check if an image of a given shape and dtype should be tiled for GPU processing.
+    Tiling is recommended if the image size is > 95% of the GPU's max allocation size.
+    or if the combined size of input and output buffers exceeds available VRAM.
+    """
+    from lls_core.utils import get_max_allocation_size, get_global_mem_size
+
+    max_alloc = get_max_allocation_size()
+    global_mem = get_global_mem_size()
+
+    if not max_alloc or not global_mem:
+        # If we can't get GPU memory, it's safer to tile.
+        logger.warning("Could not determine GPU memory information. Falling back to tiling.")
+        return True
+
+    # All GPU buffers are float32 (pyclesperanto converts internally)
+    BYTES_PER_ELEMENT = 4
+    output_bytes = math.prod(output_shape) * BYTES_PER_ELEMENT
+    input_bytes = math.prod(input_shape) * BYTES_PER_ELEMENT
+
+    # Check 1: A single buffer cannot exceed MAX_MEM_ALLOC_SIZE.
+    if output_bytes > max_alloc:
+        logger.info(
+            f"Output volume ({output_bytes / 1e6:.2f} MB) exceeds GPU max single allocation "
+            f"({max_alloc / 1e6:.2f} MB). Tiling will be used."
+        )
+        return True
+
+    # Check 2: Input + output (with 2x safety factor for internal temp iages)
+    # should not exceed total VRAM.
+    total_required_bytes = (input_bytes + output_bytes) * 2
+    if total_required_bytes > global_mem:
+        logger.info(
+            f"Estimated GPU memory ({total_required_bytes / 1e6:.2f} MB) exceeds "
+            f"total GPU memory ({global_mem / 1e6:.2f} MB). Tiling will be used."
+        )
+        return True
+
+    logger.info(f"Output volume ({output_bytes / 1e6:.2f} MB) fits in GPU memory. Processing as a whole.")
+    return False
+
+
+def get_xy_tile_sizes(
+    input_shape: Tuple[int, int, int],
+    output_shape: Tuple[int, int, int],
+    skew_dir: DeskewDirection = DeskewDirection.Y,
+) -> Tuple[int, int]:
+    """Compute (tile_y, tile_x) for XY-only tiling with full Z per tile.
+
+    Each OpenCL buffer must fit in MAX_MEM_ALLOC_SIZE, and the total of
+    input + output (with 2x safety for temporaries) must fit in VRAM.
+
+    For full-Z tiles the input subvolume spans nearly the full input
+    along the shear axis (Y for DeskewDirection.Y, X for DeskewDirection.X)
+    because the inverse affine maps the full Z range across it.  Reducing
+    the *non-shear* axis shrinks both input and output proportionally, so
+    it is halved first.
+
+    Returns:
+        (tile_y, tile_x) — full output Y/X if no tiling is needed.
+    """
+    from lls_core.utils import get_max_allocation_size, get_global_mem_size
+
+    BYTES_PER_ELEMENT = 4  # float32 on GPU
+    max_alloc = get_max_allocation_size() or (500 * 1024 * 1024)
+    global_mem = get_global_mem_size() or (2 * 1024 * 1024 * 1024)
+
+    iz, iy, ix = input_shape
+    oz, oy, ox = output_shape
+    tile_y, tile_x = oy, ox
+
+    def _exceeds_limits(ty: int, tx: int) -> bool:
+        output_bytes = oz * ty * tx * BYTES_PER_ELEMENT
+        # Input subvolume: shear axis spans full input extent,
+        # non-shear axis tracks the tile size proportionally.
+        if skew_dir == DeskewDirection.Y:
+            input_bytes = iz * iy * tx * BYTES_PER_ELEMENT
+        else:  # DeskewDirection.X
+            input_bytes = iz * ty * ix * BYTES_PER_ELEMENT
+        if output_bytes > max_alloc or input_bytes > max_alloc:
+            return True
+        if (input_bytes + output_bytes) * 2 > global_mem:
+            return True
+        return False
+
+    while _exceeds_limits(tile_y, tile_x) and (tile_y > 32 or tile_x > 32):
+        # Halve the non-shear axis first (shrinks both input and output).
+        if skew_dir == DeskewDirection.Y:
+            # X is non-shear; halve X first, then Y.
+            if tile_x > 32:
+                tile_x = max(32, tile_x // 2)
+            else:
+                tile_y = max(32, tile_y // 2)
+        else:  # DeskewDirection.X
+            # Y is non-shear; halve Y first, then X.
+            if tile_y > 32:
+                tile_y = max(32, tile_y // 2)
+            else:
+                tile_x = max(32, tile_x // 2)
+
+    return (tile_y, tile_x)
+
+
+def _compute_overlap_margin(chunk_size: int, fraction: float = 0.1) -> int:
+    """Compute overlap margin as a percentage of the tile's chunk size.
+
+    Args:
+        chunk_size: Number of pixels in this dimension's chunk.
+        fraction: Fraction of chunk_size to use as margin on each side.
+            Defaults to 10%.
+
+    Returns:
+        Margin in pixels (at least 2).
+    """
+    #TODO: Could make this configurable
+    return max(2, int(math.ceil(chunk_size * fraction)))
+
+
+def _deskew_tile(
+    block: NDArray,
+    block_info: dict | None = None,
+    original_volume: ArrayLike | None = None,
+    angle_in_degrees: float = 30,
+    voxel_size_x: float = 1.0,
+    voxel_size_y: float = 1.0,
+    voxel_size_z: float = 1.0,
+    skew_dir: DeskewDirection = DeskewDirection.Y,
+    deconvolution: bool = False,
+    decon_processing: DeconvolutionChoice | None = None,
+    psf: Psf | None = None,
+    num_iter: int = 10,
+    background: Union[float, str] = 0,
+    offset: Optional[Tuple[int, int, int]] = None,
+    y_margin: int = 0,
+    x_margin: int = 0,
+    total_output_shape: Tuple[int, int, int] = (0, 0, 0),
+) -> NDArray:
+    """Process one XY tile (full Z) via ``crop_volume_deskew``.
+
+    Called by dask ``map_blocks`` from :func:`deskew_large_image`.
+    Chunks are ``(full_z, tile_y, tile_x)`` so Z is never tiled.
+    A small margin is applied on the shear axis (Y or X depending on
+    ``skew_dir``) to handle rounding at tile boundaries.
+    """
+    if block_info is None or original_volume is None:
+        raise ValueError("block_info and original_volume must be provided")
+
+    total_oz, total_oy, total_ox = total_output_shape
+
+    expected_shape = block.shape
+    loc = block_info[0]["array-location"]
+    z_start, z_end = loc[0]
+    y_start, y_end = loc[1]
+    x_start, x_end = loc[2]
+
+    if offset:
+        z_start += offset[0]
+        z_end += offset[0]
+        y_start += offset[1]
+        y_end += offset[1]
+        x_start += offset[2]
+        x_end += offset[2]
+
+    # Expand shear axis by margin, trim afterwards
+    y_start_exp = max(0, y_start - y_margin)
+    y_end_exp = min(total_oy, y_end + y_margin) if total_oy > 0 else y_end + y_margin
+    x_start_exp = max(0, x_start - x_margin)
+    x_end_exp = min(total_ox, x_end + x_margin) if total_ox > 0 else x_end + x_margin
+
+    roi_shape = [
+        [y_start_exp, x_start_exp],
+        [y_start_exp, x_end_exp],
+        [y_end_exp, x_end_exp],
+        [y_end_exp, x_start_exp],
+    ]
+
+    result = crop_volume_deskew(
+        original_volume=original_volume,
+        roi_shape=roi_shape,
+        z_start=z_start,
+        z_end=z_end,
+        angle_in_degrees=angle_in_degrees,
+        voxel_size_x=voxel_size_x,
+        voxel_size_y=voxel_size_y,
+        voxel_size_z=voxel_size_z,
+        skew_dir=skew_dir,
+        deconvolution=deconvolution,
+        decon_processing=decon_processing,
+        psf=psf,
+        num_iter=num_iter,
+        background=background,
+        debug=False,
+        get_deskew_and_decon=False,
+    )
+
+    # Fit to expanded shape, then trim margins
+    expanded_expected = (
+        z_end - z_start,
+        y_end_exp - y_start_exp,
+        x_end_exp - x_start_exp,
+    )
+    result = _fit_to_shape(result, expanded_expected)
+
+    y_trim = y_start - y_start_exp
+    x_trim = x_start - x_start_exp
+    result = result[
+        :,
+        y_trim : y_trim + (y_end - y_start),
+        x_trim : x_trim + (x_end - x_start),
+    ]
+
+    if result.shape != expected_shape:
+        output_block = np.zeros(expected_shape, dtype=result.dtype)
+        slicers = tuple(slice(0, min(result.shape[i], expected_shape[i])) for i in range(result.ndim))
+        output_block[slicers] = result[slicers]
+        return output_block
+    return result
+
+
+def deskew_large_image(
+    original_volume: ArrayLike,
+    deskewed_shape: Tuple[int, int, int],
+    angle_in_degrees: float,
+    voxel_size_x: float,
+    voxel_size_y: float,
+    voxel_size_z: float,
+    skew_dir: DeskewDirection,
+    deconvolution: bool = False,
+    decon_processing: Optional[DeconvolutionChoice] = None,
+    psf: Optional[Psf] = None,
+    num_iter: int = 10,
+    background: Union[float, str] = 0,
+    offset: Optional[Tuple[int, int, int]] = None,
+) -> DaskArray:
+    oz, oy, ox = deskewed_shape
+
+    # XY-only tile sizes — full Z per tile
+    tile_y, tile_x = get_xy_tile_sizes(
+        original_volume.shape, deskewed_shape, skew_dir
+    )
+    chunks = (oz, tile_y, tile_x)
+    n_tiles_y = math.ceil(oy / tile_y)
+    n_tiles_x = math.ceil(ox / tile_x)
+
+    # Overlap margin on the shear axis — only when there are multiple tiles
+    if skew_dir == DeskewDirection.Y:
+        y_margin = _compute_overlap_margin(tile_y) if n_tiles_y > 1 else 0
+        x_margin = 0
+    else:
+        y_margin = 0
+        x_margin = _compute_overlap_margin(tile_x) if n_tiles_x > 1 else 0
+
+    logger.info(
+        f"Tiling: chunks={chunks}, Y margin={y_margin}, X margin={x_margin}"
+    )
+
+    template = da.zeros(deskewed_shape, chunks=chunks, dtype=np.float32)
+
+    deskewed = template.map_blocks(
+        _deskew_tile,
+        dtype=np.float32,
+        chunks=chunks,
+        original_volume=original_volume,
+        angle_in_degrees=angle_in_degrees,
+        voxel_size_x=voxel_size_x,
+        voxel_size_y=voxel_size_y,
+        voxel_size_z=voxel_size_z,
+        skew_dir=skew_dir,
+        deconvolution=deconvolution,
+        decon_processing=decon_processing,
+        psf=psf,
+        num_iter=num_iter,
+        background=background,
+        offset=offset,
+        y_margin=y_margin,
+        x_margin=x_margin,
+        total_output_shape=deskewed_shape,
+    )
+
+    return deskewed

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -24,6 +24,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class LatticeData(OutputParams, DeskewParams):
     """
     Parameters for the entire deskewing process, including outputs and optional steps such as deconvolution.
@@ -69,10 +70,10 @@ class LatticeData(OutputParams, DeskewParams):
             save_dir = values.get("save_dir")
             if save_dir is None:
                 # By default, make the save dir be the same dir as the input
-                values["save_dir"] = Path(input_image).parent
+                values["save_dir"] = Path(input_image).resolve().parent
             elif is_pathlike(save_dir):
                 # Convert a string path to a Path object
-                values["save_dir"] = Path(save_dir)
+                values["save_dir"] = Path(save_dir).resolve()
 
         # Use the Deskew version of this validator, to do the actual image loading
         return super().read_image(values)
@@ -244,6 +245,23 @@ class LatticeData(OutputParams, DeskewParams):
         "True if deconvolution should be performed"
         return self.deconvolution is not None
 
+    @property
+    def uses_gpu(self) -> bool:
+        """
+        Returns True if any part of the processing pipeline uses the GPU.
+        """
+        import pyclesperanto_prototype as cle
+        # Deskewing with pyclesperanto uses the selected device.
+        # A device is assumed to be a GPU unless its name contains "cpu".
+        # This is more robust than checking for "gpu"/"graphics" keywords,
+        # since NVIDIA/AMD GPUs often don't include those substrings
+        # (e.g. "NVIDIA GeForce RTX 3090", "AMD Radeon RX 6800").
+        device_name = cle.get_device().name.lower()
+        is_gpu_device = "cpu" not in device_name
+        # Deconvolution can also be on the GPU.
+        use_gpu_decon = self.deconvolution is not None and self.deconvolution.decon_processing in [DeconvolutionChoice.cuda_gpu, DeconvolutionChoice.opencl_gpu]
+        return is_gpu_device or use_gpu_decon
+
     def __post_init__(self):
         logger.info(f"Channels: {self.channels}, Time: {self.time}")
         logger.info("If channel and time need to be swapped, you can enforce this by choosing 'Last dimension is channel' when initialising the plugin")
@@ -361,22 +379,64 @@ class LatticeData(OutputParams, DeskewParams):
         """
         Yields processed image slices with cropping enabled
         """
+        from lls_core.llsz_core import deskew_large_image, _should_tile_on_gpu
+        import numpy as np
+
         if self.crop is None:
             raise Exception("This function can only be called when crop is set")
         
         for slice in self.iter_slices():
             roi_index = cast(int, slice.roi_index)
             roi = self.crop.roi_list[roi_index]
-            deconv_args: dict[Any, Any] = {}
-            if self.deconvolution is not None:
-                deconv_args = dict(
-                    num_iter = self.deconvolution.decon_num_iter,
-                    psf = self.deconvolution.psf[slice.channel].to_numpy(),
-                    decon_processing=self.deconvolution.decon_processing
-                )
 
-            yield slice.copy(update={
-                "data": crop_volume_deskew(
+            # Calculate shape of cropped region in deskewed space
+            z_start, z_end = self.crop.z_range
+            y_coords = [p[0] for p in roi]
+            x_coords = [p[1] for p in roi]
+            y_min, y_max = int(min(y_coords)), int(max(y_coords))
+            x_min, x_max = int(min(x_coords)), int(max(x_coords))
+
+            crop_output_shape = (z_end - z_start, y_max - y_min, x_max - x_min)
+        
+            # We should consider tiling if the selected pyclesperanto device is a GPU,
+            # as deskewing will happen on it regardless of deconvolution settings.
+            if self.uses_gpu and _should_tile_on_gpu(slice.data.shape, crop_output_shape, np.float32):
+                # Use tiling for this large crop
+                deconv_args = {}
+                if self.deconvolution is not None:
+                    deconv_args = dict(
+                        deconvolution=True,
+                        decon_processing=self.deconvolution.decon_processing,
+                        psf=self.deconvolution.psf[slice.channel].to_numpy(),
+                        num_iter=self.deconvolution.decon_num_iter,
+                        background=self.deconvolution.background,
+                    )
+                from lls_core.models.results import _ensure_numpy
+                deskewed_data = _ensure_numpy(
+                    deskew_large_image(
+                        original_volume=slice.data,
+                        deskewed_shape=crop_output_shape,
+                        angle_in_degrees=self.angle,
+                        voxel_size_x=self.dx,
+                        voxel_size_y=self.dy,
+                        voxel_size_z=self.dz,
+                        skew_dir=self.skew,
+                        offset=(z_start, y_min, x_min),
+                        **deconv_args,
+                    ),
+                    use_gpu=self.uses_gpu,
+                )
+            else:
+                # Process this crop in-memory
+                deconv_args = {}
+                if self.deconvolution is not None:
+                    deconv_args = dict(
+                        num_iter=self.deconvolution.decon_num_iter,
+                        psf=self.deconvolution.psf[slice.channel].to_numpy(),
+                        decon_processing=self.deconvolution.decon_processing,
+                        background=self.deconvolution.background,
+                    )
+                deskewed_data = crop_volume_deskew(
                     original_volume=slice.data,
                     deconvolution=self.deconv_enabled,
                     get_deskew_and_decon=False,
@@ -387,11 +447,14 @@ class LatticeData(OutputParams, DeskewParams):
                     voxel_size_y=self.dy,
                     voxel_size_z=self.dz,
                     angle_in_degrees=self.angle,
-                    deskewed_volume=self.deskewed_volume,
+                    skew_dir=self.skew,
                     z_start=self.crop.z_range[0],
                     z_end=self.crop.z_range[1],
-                    **deconv_args
-                ),
+                    **deconv_args,
+                )
+
+            yield slice.copy(update={
+                "data": deskewed_data,
                 "roi_index": roi_index
             })
             
@@ -399,12 +462,28 @@ class LatticeData(OutputParams, DeskewParams):
         """
         Yields processed image slices without cropping
         """
+        from lls_core.llsz_core import deskew_xy_tiles, _should_tile_on_gpu
+        import numpy as np
         import pyclesperanto_prototype as cle
+
+        # Check once whether tiling is needed for this image
+        tile = self.uses_gpu and _should_tile_on_gpu(
+            self.slice_data(0, 0).shape, self.derived.deskew_vol_shape, np.float32
+        )
+
+        # Capture the original input dtype so output can match it
+        original_dtype = self.input_image.dtype
 
         for slice in self.iter_slices():
             data: ArrayLike = slice.data
-            if isinstance(slice.data, DaskArray):
-                data = slice.data.compute()
+
+            # Always pre-load into RAM to avoid repeated disk I/O
+            if isinstance(data, DaskArray):
+                data = data.compute()
+            elif not isinstance(data, np.ndarray):
+                data = np.asarray(data)
+
+            # Deconvolution (before deskewing, same order as non-tiled path)
             if self.deconvolution is not None:
                 if self.deconvolution.decon_processing == DeconvolutionChoice.cuda_gpu:
                     data = pycuda_decon(
@@ -415,7 +494,7 @@ class LatticeData(OutputParams, DeskewParams):
                         dxdata=self.dx,
                         dzpsf=self.dz,
                         dxpsf=self.dx,
-                        num_iter=self.deconvolution.decon_num_iter
+                        num_iter=self.deconvolution.decon_num_iter,
                     )
                 else:
                     data = skimage_decon(
@@ -424,19 +503,40 @@ class LatticeData(OutputParams, DeskewParams):
                         num_iter=self.deconvolution.decon_num_iter,
                         clip=False,
                         filter_epsilon=0,
-                        boundary='nearest'
+                        boundary="nearest",
                     )
 
-            yield slice.copy_with_data(
-                cle.pull_zyx(self.deskew_func(
-                    input_image=data,
+            if tile:
+                deskewed = deskew_xy_tiles(
+                    input_volume=data,
+                    deskew_vol_shape=self.derived.deskew_vol_shape,
                     angle_in_degrees=self.angle,
-                    linear_interpolation=True,
                     voxel_size_x=self.dx,
                     voxel_size_y=self.dy,
-                    voxel_size_z=self.dz
-                ))
-            )
+                    voxel_size_z=self.dz,
+                    skew_dir=self.skew,
+                    output_dtype=original_dtype,
+                )
+                yield slice.copy_with_data(deskewed)
+            else:
+                deskewed_in_mem = cle.pull_zyx(
+                    self.deskew_func(
+                        input_image=data,
+                        angle_in_degrees=self.angle,
+                        linear_interpolation=True,
+                        voxel_size_x=self.dx,
+                        voxel_size_y=self.dy,
+                        voxel_size_z=self.dz,
+                    )
+                )
+                # Convert output to match input dtype
+                if deskewed_in_mem.dtype != original_dtype:
+                    if np.issubdtype(original_dtype, np.integer):
+                        iinfo = np.iinfo(original_dtype)
+                        deskewed_in_mem = np.clip(deskewed_in_mem, iinfo.min, iinfo.max).astype(original_dtype)
+                    else:
+                        deskewed_in_mem = deskewed_in_mem.astype(original_dtype)
+                yield slice.copy_with_data(deskewed_in_mem)
 
     def process_workflow(self) -> WorkflowSlices:
         """

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -471,8 +471,12 @@ class LatticeData(OutputParams, DeskewParams):
             self.slice_data(0, 0).shape, self.derived.deskew_vol_shape, np.float32
         )
 
-        # Capture the original input dtype so output can match it
+        # Capture the original input dtype so integer outputs can match it.
+        # For floating-point inputs we keep the GPU's native float32 to avoid
+        # upcasting to float64 (which ImageJ TIFF doesn't support).
         original_dtype = self.input_image.dtype
+        if not np.issubdtype(original_dtype, np.integer):
+            original_dtype = np.dtype(np.float32)
 
         for slice in self.iter_slices():
             data: ArrayLike = slice.data

--- a/core/lls_core/models/results.py
+++ b/core/lls_core/models/results.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from lls_core.models.lattice_data import LatticeData
 
+
+def _ensure_numpy(data: ArrayLike, use_gpu: bool) -> ArrayLike:
+    """Compute dask arrays serially when using GPU to avoid VRAM exhaustion."""
+    from dask.array.core import Array as DaskArray
+    if isinstance(data, DaskArray) and use_gpu:
+        return data.compute(scheduler="single-threaded")
+    return data
+
+
 T = TypeVar("T")
 S = TypeVar("S")
 R = TypeVar("R")
@@ -79,10 +88,11 @@ class ImageSlices(ProcessedSlices[ArrayLike]):
         """
         Extracts a single 3D image for each ROI
         """
-        import numpy as np
+        use_gpu = self.lattice_data.uses_gpu
+
         def _preview(slices: Iterable[ProcessedSlice[ArrayLike]]) -> ArrayLike:
             for slice in slices:
-                return slice.data
+                return _ensure_numpy(slice.data, use_gpu)
             raise Exception("This ROI has no images. This shouldn't be possible")
 
         for roi_index, slices in groupby(self.slices, key=lambda slice: slice.roi_index):
@@ -157,24 +167,26 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
         from lls_core.models.lattice_data import LatticeData
         ProcessedWorkflowOutput.update_forward_refs(LatticeData=LatticeData)
 
+        use_gpu = self.lattice_data.uses_gpu
+
         # Handle each ROI separately
         for roi, roi_results in groupby(self.slices, key=lambda it: it.roi_index):
             values: list[Union[Writer, list]] = []
             for result in roi_results:
                 # If the user didn't return a tuple, put it into one
                 for i, element in enumerate(result.as_tuple()):
+                    slice_to_write = result.copy_with_data(element)
                     # If the element is array like, we assume it's an image to write to disk
-                    if is_arraylike(element):
+                    if is_arraylike(slice_to_write.data):
                         # Make the writer the first time only
                         if len(values) <= i:
                             values.append(self.lattice_data.get_writer()(self.lattice_data, roi_index=roi))
 
                         writer = cast(Writer, values[i])
-                        writer.write_slice(
-                            result.copy_with_data(
-                                element
-                            )
+                        slice_to_write = slice_to_write.copy_with_data(
+                            _ensure_numpy(slice_to_write.data, use_gpu)
                         )
+                        writer.write_slice(slice_to_write)
                     else:
                         # Otherwise, we assume it's one row to be added to a data frame
                         if len(values) <= i:
@@ -233,11 +245,13 @@ class WorkflowSlices(ProcessedSlices[MaybeTupleRawWorkflowOutput]):
         Extracts a single 3D image for each ROI
         """
         import numpy as np
+        use_gpu = self.lattice_data.uses_gpu
+
         def _preview(slices: Iterable[ProcessedSlice[MaybeTupleRawWorkflowOutput]]) -> NDArray:
             for slice in slices:
                 for value in slice.as_tuple():
                     if is_arraylike(value):
-                        return np.asarray(value)
+                        return np.asarray(_ensure_numpy(value, use_gpu))
             raise Exception("This ROI has no images. This shouldn't be possible")
 
         for roi_index, slices in groupby(self.slices, key=lambda slice: slice.roi_index):

--- a/core/lls_core/utils.py
+++ b/core/lls_core/utils.py
@@ -365,3 +365,26 @@ def get_zarr_compression():
                 shuffle=Blosc.SHUFFLE,
             )
         )
+
+
+def get_max_allocation_size():
+    """Returns maximum memory allocation size for the currently selected OpenCL device.
+    Returns:
+        int or None: Maximum allocation size in bytes, or None if unavailable.
+    """
+    try:
+        return cle.get_device().device.max_mem_alloc_size
+    except Exception:
+        logger.error("Could not determine MAX_MEM_ALLOC_SIZE for the selected device")
+        return None
+
+def get_global_mem_size():
+    """Returns global memory size for the currently selected OpenCL device in bytes.
+    Returns:
+        int or None: Global memory size in bytes, or None if unavailable.
+    """
+    try:
+        return cle.get_device().device.global_mem_size
+    except Exception:
+        logger.error("Could not determine GLOBAL_MEM_SIZE for the selected device")
+        return None

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -16,6 +16,10 @@ import numpy as np
 import zarr
 
 from lls_core.utils import make_filename_suffix, get_zarr_compression
+
+import logging
+logger = logging.getLogger(__name__)
+
 RoiIndex = Optional[NonNegativeInt]
 
 if TYPE_CHECKING:
@@ -97,16 +101,10 @@ class TiffWriter(Writer):
         self.pending_slices = []
     
     def flush(self):
-        "Write out all pending slices"
-        import numpy as np
+        "Write out all pending slices to a TIFF file"
         import tifffile
         if len(self.pending_slices) > 0:
             first_result = self.pending_slices[0]
-            images_array = np.swapaxes(
-                np.expand_dims([result.data for result in self.pending_slices], axis=0),
-                1, 2
-            ).astype("uint16")
-            # ImageJ TIFF can only handle 16-bit uints, not 32
             path = self.lattice.make_filepath(
                 make_filename_suffix(
                     channel=first_result.channel,
@@ -114,19 +112,70 @@ class TiffWriter(Writer):
                     roi_index=first_result.roi_index
                 )
             )
-            tifffile.imwrite(
-                str(path),
-                data = images_array,
-                bigtiff=True,
-                resolution=(1./self.lattice.dx, 1./self.lattice.dy),
-                resolutionunit="MICROMETER",
-                metadata={'spacing': self.lattice.new_dz, 'unit': 'um', 'axes': 'TZCYX'},
-                imagej=True
-            )
+
+            n_channels = len(self.pending_slices)
+
+            if n_channels == 1:
+                # Single channel: write directly using imwrite.
+                # For memmap-backed data, tifffile iterates Z-pages lazily,
+                # avoiding loading the full volume into RAM.
+                # Reshape to 5D (T,Z,C,Y,X) so tifffile correctly identifies
+                # the Z dimension as slices (not channels). reshape() on a
+                # memmap creates a view — no data is copied.
+                data = np.asarray(self.pending_slices[0].data)
+                z, y, x = data.shape
+                data_5d = data.reshape(1, z, 1, y, x)
+                tifffile.imwrite(
+                    str(path),
+                    data=data_5d,
+                    bigtiff=True,
+                    imagej=True,
+                    resolution=(1./self.lattice.dx, 1./self.lattice.dy),
+                    resolutionunit="MICROMETER",
+                    metadata={'spacing': self.lattice.new_dz, 'unit': 'um', 'axes': 'TZCYX'},
+                )
+            else:
+                # Multi-channel: build TZCYX array and write at once.
+                # Preserve the data's native dtype (uint8 labels, uint16
+                # intensity, float32 workflow outputs, etc.).
+                images_array = np.swapaxes(
+                    np.expand_dims(
+                        [np.asarray(result.data) for result in self.pending_slices],
+                        axis=0,
+                    ),
+                    1, 2,
+                )
+                tifffile.imwrite(
+                    str(path),
+                    data=images_array,
+                    bigtiff=True,
+                    imagej=True,
+                    resolution=(1./self.lattice.dx, 1./self.lattice.dy),
+                    resolutionunit="MICROMETER",
+                    metadata={'spacing': self.lattice.new_dz, 'unit': 'um', 'axes': 'TZCYX'},
+                )
+
             self.written_files.append(path)
-            
-            # Reinitialise
+
+            # Clean up memmap temp files if any slices were backed by memmap
+            memmap_paths = set()
+            for result in self.pending_slices:
+                if isinstance(result.data, np.memmap):
+                    p = getattr(result.data, 'filename', None)
+                    if p:
+                        memmap_paths.add(p)
+
             self.pending_slices = []
+
+            if memmap_paths:
+                import gc, os
+                gc.collect()
+                for p in memmap_paths:
+                    try:
+                        os.unlink(p)
+                        logger.info(f"Cleaned up memmap temp file: {p}")
+                    except OSError:
+                        pass
 
     def write_slice(self, slice: ProcessedSlice[ArrayLike]):
         if slice.time != self.time:
@@ -180,6 +229,30 @@ class OMEZarrWriter(Writer):
 
         self._pix_z, self._pix_y, self._pix_x = (self.lattice.new_dz, self.lattice.dy, self.lattice.dx)
 
+    def ensure_initialized(self, zyx_shape: tuple[int, int, int], t_len: int, c_len: int, dtype) -> zarr.Array:
+        """Pre-create the zarr store and return the backing array.
+
+        This allows callers (e.g. the direct-write tiling path) to obtain
+        the zarr array before any ``write_slice()`` calls, so they can
+        write slabs directly into the array.
+
+        Args:
+            zyx_shape: (Z, Y, X) dimensions of a single 3D volume.
+            t_len: Number of time points.
+            c_len: Number of channels.
+            dtype: Data type for the array.
+
+        Returns:
+            The zarr.Array backing this store (shape: ``(t, c, z, y, x)``).
+        """
+        self._zyx = (int(zyx_shape[0]), int(zyx_shape[1]), int(zyx_shape[2]))
+        self._t_len = t_len
+        self._c_len = c_len
+        self._dtype = np.dtype(dtype)
+        if self._arr is None:
+            self._root_group, self._arr = self._create_store(t_len, c_len, self._zyx, self._dtype)
+        return self._arr
+
     def write_slice(self, slice) -> Path:
         """Write a 3D (Z,Y,X) slice into (t,c,:,:,:) and return root .ome.zarr path."""
         data3d = self._to_numpy(getattr(slice, "data", slice))
@@ -189,13 +262,9 @@ class OMEZarrWriter(Writer):
         if self._zyx is None:
             self._zyx = (int(data3d.shape[0]), int(data3d.shape[1]), int(data3d.shape[2]))
 
-        #if dtype of data is < uint16, use the data dtype
-        if np.issubdtype(data3d.dtype, np.integer):
-            self._dtype = (data3d.dtype
-                            if np.iinfo(data3d.dtype).max < np.iinfo(np.uint16).max
-                            else np.uint16)
-        elif np.issubdtype(data3d.dtype, np.floating):
-            #float data, so preserve dtype
+        # Preserve the data's native dtype so label images (uint8, uint32)
+        # and float workflow outputs are not silently truncated.
+        if np.issubdtype(data3d.dtype, np.integer) or np.issubdtype(data3d.dtype, np.floating):
             self._dtype = data3d.dtype
         else:
             raise TypeError(f"Unsupported data dtype: {data3d.dtype}")
@@ -208,7 +277,15 @@ class OMEZarrWriter(Writer):
         if self._arr is None:
             self._root_group, self._arr = self._create_store(t_len, c_len, self._zyx, self._dtype)
         
-        self._arr[t_idx, c_idx, :, :, :] = np.clip(data3d, 0.0, 65535.0).astype(np.uint16)
+        # Convert to the store dtype.  For integer targets, clip to the
+        # valid range to avoid wrap-around; for floats, cast directly.
+        if np.issubdtype(self._dtype, np.integer):
+            info = np.iinfo(self._dtype)
+            self._arr[t_idx, c_idx, :, :, :] = np.clip(
+                data3d, float(info.min), float(info.max)
+            ).astype(self._dtype)
+        else:
+            self._arr[t_idx, c_idx, :, :, :] = data3d.astype(self._dtype)
         return self._root_path
 
     # Optional hook if the framework ever calls it.
@@ -233,25 +310,43 @@ class OMEZarrWriter(Writer):
 
         chunks = (1, 1, *self.chunk_zyx)
 
-        compression_kwargs = get_zarr_compression()
-        #adding compatibility fix for zarr v2 and v3
-        if int(zarr.__version__.split(".")[0]) >= 3:
-            #zarr v3: group class cannot be constructed from path directly
-            root = zarr.open_group(store=str(self._root_path), mode="a")
+        zarr_major = int(zarr.__version__.split(".")[0])
+
+        # Always write zarr v2-format stores for maximum compatibility
+        # (Fiji, OMERO, QuPath, napari).  Use numcodecs compressor
+        # regardless of zarr library version since zarr_format=2
+        # requires numcodecs, not zarr.codecs.
+        from numcodecs import Blosc as _Blosc
+        compressor = _Blosc(cname="zstd", clevel=5, shuffle=_Blosc.SHUFFLE)
+
+        if zarr_major >= 3:
+            root = zarr.open_group(
+                store=str(self._root_path),
+                mode="a",
+                zarr_format=2,
+            )
         else:
-            store = zarr.DirectoryStore(str(self._root_path))
+            store = zarr.DirectoryStore(
+                str(self._root_path),
+                dimension_separator="/",
+            )
             root = zarr.group(store=store)
 
         dataset_kwargs = {
             "shape": (t_len, c_len, zyx[0], zyx[1], zyx[2]),
             "chunks": chunks,
             "dtype": dtype,
-            **compression_kwargs,
+            "compressor": compressor,
         }
-        if int(zarr.__version__.split(".")[0]) < 3:
+        if zarr_major < 3:
             dataset_kwargs["overwrite"] = self.overwrite
+            dataset_kwargs["dimension_separator"] = "/"
 
         arr = root.create_dataset("0", **dataset_kwargs)
+
+        # _ARRAY_DIMENSIONS is expected by xarray and some NGFF readers
+        arr.attrs["_ARRAY_DIMENSIONS"] = ["t", "c", "z", "y", "x"]
+
         self._write_ngff_attrs(root)
         return root, arr
 

--- a/core/tests/test_tiling.py
+++ b/core/tests/test_tiling.py
@@ -1,0 +1,128 @@
+"""Tests for XY-tiling deskew."""
+from __future__ import annotations
+
+from unittest.mock import patch
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lls_core import DeskewDirection
+from lls_core.llsz_core import (
+    _should_tile_on_gpu,
+    deskew_xy_tiles,
+    get_xy_tile_sizes,
+)
+from lls_core.models import LatticeData
+from lls_core.models.output import SaveFileType
+from lls_core.utils import get_deskewed_shape
+
+
+# ---------------------------------------------------------------------------
+# _should_tile_on_gpu
+# ---------------------------------------------------------------------------
+
+def test_should_tile_small_fits():
+    with patch("lls_core.utils.get_max_allocation_size", return_value=2 * 1024**3), \
+         patch("lls_core.utils.get_global_mem_size", return_value=8 * 1024**3):
+        assert _should_tile_on_gpu((30, 64, 64), (30, 128, 64), np.float32) is False
+
+
+def test_should_tile_large_exceeds():
+    with patch("lls_core.utils.get_max_allocation_size", return_value=100 * 1024**2), \
+         patch("lls_core.utils.get_global_mem_size", return_value=8 * 1024**3):
+        assert _should_tile_on_gpu((512, 512, 512), (512, 1024, 512), np.float32) is True
+
+
+# ---------------------------------------------------------------------------
+# get_xy_tile_sizes
+# ---------------------------------------------------------------------------
+
+def test_tile_sizes_small_no_split():
+    with patch("lls_core.utils.get_max_allocation_size", return_value=2 * 1024**3), \
+         patch("lls_core.utils.get_global_mem_size", return_value=8 * 1024**3):
+        tile_y, tile_x = get_xy_tile_sizes((30, 64, 64), (30, 128, 64))
+        assert tile_y == 128
+        assert tile_x == 64
+
+
+def test_tile_sizes_large_reduced():
+    with patch("lls_core.utils.get_max_allocation_size", return_value=50 * 1024**2), \
+         patch("lls_core.utils.get_global_mem_size", return_value=200 * 1024**2):
+        tile_y, tile_x = get_xy_tile_sizes(
+            (200, 2000, 2000), (200, 4000, 2000), DeskewDirection.Y
+        )
+        assert tile_x < 2000 or tile_y < 4000
+        assert tile_y >= 32 and tile_x >= 32
+
+
+# ---------------------------------------------------------------------------
+# deskew_xy_tiles
+# ---------------------------------------------------------------------------
+
+def test_deskew_xy_tiles_shape_and_content():
+    """Tiled deskew produces correct shape with non-zero output."""
+    rng = np.random.default_rng(42)
+    vol = rng.integers(0, 1000, size=(30, 64, 64), dtype=np.uint16)
+    shape, _ = get_deskewed_shape(vol, 30.0, 0.15, 0.15, 0.3, DeskewDirection.Y)
+    shape = tuple(shape)
+
+    result = deskew_xy_tiles(vol, shape, 30.0, 0.15, 0.15, 0.3, DeskewDirection.Y)
+    assert result.shape == shape
+    assert result.max() > 0
+
+
+def test_deskew_xy_tiles_skew_x():
+    rng = np.random.default_rng(42)
+    vol = rng.integers(0, 1000, size=(30, 64, 64), dtype=np.uint16)
+    shape, _ = get_deskewed_shape(vol, 30.0, 0.15, 0.15, 0.3, DeskewDirection.X)
+    shape = tuple(shape)
+
+    result = deskew_xy_tiles(vol, shape, 30.0, 0.15, 0.15, 0.3, DeskewDirection.X)
+    assert result.shape == shape
+    assert result.max() > 0
+
+
+def test_deskew_xy_tiles_dtype():
+    rng = np.random.default_rng(42)
+    vol = rng.integers(0, 1000, size=(20, 48, 48), dtype=np.uint16)
+    shape, _ = get_deskewed_shape(vol, 30.0, 0.15, 0.15, 0.3)
+    result = deskew_xy_tiles(
+        vol, tuple(shape), 30.0, 0.15, 0.15, 0.3,
+        DeskewDirection.Y, output_dtype=np.uint16,
+    )
+    assert result.dtype == np.uint16
+
+
+# ---------------------------------------------------------------------------
+# Integration: LatticeData pipeline with forced tiling
+# ---------------------------------------------------------------------------
+
+def test_tiled_pipeline_process(rbc_tiny):
+    """Full pipeline with tiling forced produces correct output."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = LatticeData.parse_obj({
+            "input_image": rbc_tiny,
+            "save_dir": tmpdir,
+        })
+        with patch("lls_core.llsz_core._should_tile_on_gpu", return_value=True):
+            slices = list(lattice.process().slices)
+        assert len(slices) > 0
+        for s in slices:
+            assert s.data.ndim == 3
+            assert s.data.shape == tuple(lattice.derived.deskew_vol_shape)
+
+
+@pytest.mark.parametrize("save_type", [SaveFileType.tiff, SaveFileType.omezarr])
+def test_tiled_pipeline_save(rbc_tiny, save_type):
+    """Tiled processing produces valid output files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = LatticeData.parse_obj({
+            "input_image": rbc_tiny,
+            "save_dir": tmpdir,
+            "save_type": save_type,
+        })
+        with patch("lls_core.llsz_core._should_tile_on_gpu", return_value=True):
+            lattice.save()
+        assert len(list(Path(tmpdir).iterdir())) > 0

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -349,53 +349,47 @@ class DeskewFields(NapariFieldGroup):
     @pixel_sizes.connect
     def _quick_deskew(self):
         image: Image
-        #Apply quick deskew where image is displayed in canvas as deskewed. 
-        #get value of quick deskew
         quick_deskew = self.quick_deskew.value
-        #If quick deskew is True
         from pydantic.v1 import ValidationError
+        import numpy as np
+
         if quick_deskew:
             try:
-                #initialize lattice model
-                lattice = self._make_model() 
+                lattice = self._make_model()
             except ValidationError as e:
                 logger.info(f"Validation Error: {e}")
-                # Ignore if the deskew parameters are invalid
                 return
-            #get new pixel sizes and update scale
-            scale = (
-                    lattice.new_dz,
-                    lattice.dy,
-                    lattice.dx
-                )
-            #use zyx deskew affine transform
-            affine_transform = lattice.derived.deskew_affine_transform_zyx
+
+            # napari pipeline: data_to_world = affine @ diag(scale) @ data
+            # Preview shows:   world = diag(new_dz,dy,dx) @ T_fwd @ data
+            # pyclesperanto stores T_fwd (input→output); it inverts
+            # internally for resampling.
+            # With scale=(1,1,1): affine = diag(new_dz,dy,dx) @ T_fwd
+            deskew_forward = lattice.derived.deskew_affine_transform_zyx
+            physical_scale = np.diag([lattice.new_dz, lattice.dy, lattice.dx, 1.0])
+            affine_transform = physical_scale @ deskew_forward
+            scale = (1.0, 1.0, 1.0)
             ndim_display = 3
         else:
-            try: 
+            try:
                 pixels = self._get_kwargs()["physical_pixel_sizes"]
-                scale = (
-                            pixels.Z,
-                            pixels.Y,
-                            pixels.X,
-                        )
+                scale = (pixels.Z, pixels.Y, pixels.X)
             except:
                 scale = None
             affine_transform = None
             ndim_display = 2
 
-        #transform each image layer selected
         for image in self.img_layer.value:
-            #we do not inverse transform as napari goes from input to output space
             image.affine = affine_transform
-            image.scale = scale
-        
+            if scale is not None:
+                image.scale = (*image.scale[:-3], *scale)
+
         try:
             from napari_lattice.utils import get_viewer
             viewer = get_viewer()
             viewer.dims.ndisplay = ndim_display
             viewer.reset_view()
-        except: 
+        except:
             pass
 
     def _get_kwargs(self) -> DeskewKwargs:


### PR DESCRIPTION
Duplicate of #110 

closes https://github.com/BioimageAnalysisCoreWEHI/napari_lattice/issues/105.

This PR implements tiling to process images larger than GPU VRAM. 
Only adds XY tiling while keeping full Z depth per tile. 

- _should_tile_on_gpu() will check if input + output volumes exceed 95% of GPUs maximum allocation size or total VRAM. If not, does not need to tile and default is used
- get_xy_tile_sizes() computes optimium xy tiles that fit within GPU
- deskew_xy_tiles() will loop over XY tiles. Each will call crop_volume_deskew() for deskewing.

Additional functionality is multiprocessing so GPU processing and file saving are parallelized. 


Other changes:
- --device flag for CLI to select OpenCL device
- Fixed Quick Deskew as it did not display accurate deskewed image for non-isotropic voxels
- Added tests for tiles