### PR TITLE
Flip Scan direction

### DIFF
--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -36,6 +36,7 @@ CLI_PARAM_MAP = {
     "input_image": ["input_image"],
     "angle": ["angle"],
     "skew": ["skew"],
+    "invert_scan_direction": ["invert_scan_direction"],
     "physical_pixel_sizes": ["physical_pixel_sizes"],
     "roi_list": ["crop", "roi_list"],
     "roi_subset": ["crop", "roi_subset"],
@@ -141,6 +142,7 @@ def process(
     input_image: Path = Argument(None, help="Path to the image file to read, in a format readable by AICSImageIO, for example .tiff or .czi", show_default=False),
     skew: CliDeskewDirection = field_from_model(DeskewParams, "skew"),# DeskewParams.make_typer_field("skew"),
     angle: float = field_from_model(DeskewParams, "angle") ,
+    invert_scan_direction: bool = field_from_model(DeskewParams, "invert_scan_direction"),
     physical_pixel_sizes: Tuple[float, float, float] = field_from_model(DeskewParams, "physical_pixel_sizes", extra_description="This takes three arguments, corresponding to the Z, Y and X pixel dimensions respectively", default=(
         DefinedPixelSizes.get_default("Z"),
         DefinedPixelSizes.get_default("Y"),

--- a/core/lls_core/models/deskew.py
+++ b/core/lls_core/models/deskew.py
@@ -70,6 +70,12 @@ class DeskewParams(FieldAccessModel):
         description="Pixel size of the microscope, in microns. This can alternatively be provided as a `tuple[float]` of `(Z, Y, X)`",
         default=None
     )
+    invert_scan_direction: bool = Field(
+        default=False,
+        description="If `True`, reverse the order of planes along the scan (Z) axis before deskewing. "
+                    "This is required for oblique plane microscopes whose stage/galvo scans can be in opposite directions. "
+                    "Leaving this `False` preserves the original behaviour compatible with Zeiss LLS."
+    )
     derived: DerivedDeskewFields = Field(
         init_var=False,
         default=None,
@@ -152,6 +158,17 @@ class DeskewParams(FieldAccessModel):
         import math
         return math.sin(self.angle * math.pi / 180.0) * self.dz
 
+    def apply_scan_flip(self, volume: DataArray) -> DataArray:
+        """
+        Reverse the plane/scan (Z) axis of a volume if `invert_scan_direction` is set.
+        This is a lazy operation (a view for numpy-backed arrays, lazy for dask), so it
+        adds no measurable cost and does not introduce a second resampling pass.
+        The scan axis is always Z (the plane-stacking axis), regardless of skew direction.
+        """
+        if self.invert_scan_direction:
+            return volume.isel(Z=slice(None, None, -1))
+        return volume
+
     @validator("skew", pre=True)
     def convert_skew(cls, v: Any):
         # Allow skew to be provided as a string
@@ -226,7 +243,7 @@ class DeskewParams(FieldAccessModel):
         return array.transpose("T", "C", "Z", "Y", "X")
 
     def get_3d_slice(self) -> DataArray:
-        return self.input_image.isel(C=0, T=0)
+        return self.apply_scan_flip(self.input_image.isel(C=0, T=0))
 
     @validator("derived", always=True)
     def calculate_derived(cls, v: Any, values: dict) -> DerivedDeskewFields:
@@ -246,6 +263,19 @@ class DeskewParams(FieldAccessModel):
                 values["skew"]
             )
             deskew_affine_transform_zyx = convert_xyz_to_zyx_order(deskew_affine_transform)
+            if values.get("invert_scan_direction"):
+                # The actual deskew/crop output flips the scan (Z) axis of the data (see
+                # `apply_scan_flip`). The deskew transform itself is shape-derived and so
+                # is identical regardless of the flip, which means the in-canvas "Quick
+                # Deskew" display (the only consumer of this matrix) would otherwise ignore
+                # the flag. Fold the Z reflection into the *display* transform so that
+                # applying it to the unflipped layer reproduces the flipped-then-deskewed
+                # geometry, matching the processed/preview output.
+                nz = int(data.sizes["Z"])
+                flip_zyx = np.eye(4)
+                flip_zyx[0, 0] = -1
+                flip_zyx[0, 3] = nz - 1
+                deskew_affine_transform_zyx = deskew_affine_transform_zyx @ flip_zyx
             return DerivedDeskewFields(
                 deskew_affine_transform=deskew_affine_transform,
                 deskew_vol_shape=deskew_vol_shape,

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -254,7 +254,7 @@ class LatticeData(OutputParams, DeskewParams):
         if channel > self.channels:
             raise ValueError("channel is out of range")
 
-        return self.input_image.isel(T=time, C=channel)
+        return self.apply_scan_flip(self.input_image.isel(T=time, C=channel))
 
     def iter_roi_indices(self) -> Iterable[Optional[int]]:
         """
@@ -312,6 +312,9 @@ class LatticeData(OutputParams, DeskewParams):
                 crop = None
             new_lattice = self.copy_validate(update={
                 "input_image": subarray.data,
+                # The scan flip is already baked into subarray.data by slice_data, so
+                # disable it here to avoid flipping the volume a second time.
+                "invert_scan_direction": False,
                 "time_range": range(1),
                 "channel_range": range(1),
                 "crop": crop,

--- a/core/tests/test_deskew.py
+++ b/core/tests/test_deskew.py
@@ -26,3 +26,183 @@ def test_lattice_data_deskew():
             save_dir=tmpdir
         )
         assert lattice.derived.deskew_vol_shape == (2, 9, 5)
+
+
+def test_invert_scan_direction_slice_data():
+    # Flip should reverse the scan (Z) axis of the volume handed to the deskew
+    from lls_core.models.deskew import DeskewParams
+
+    raw_np = np.arange(5 * 4 * 3, dtype=float).reshape(5, 4, 3)
+    raw = DataArray(raw_np, dims=["Z", "Y", "X"])
+
+    normal = DeskewParams(input_image=raw, physical_pixel_sizes=(1, 1, 1))
+    inverted = DeskewParams(input_image=raw, physical_pixel_sizes=(1, 1, 1), invert_scan_direction=True)
+
+    # Default leaves orientation untouched; inverting reverses the Z axis
+    np.testing.assert_array_equal(np.asarray(normal.get_3d_slice()), raw_np)
+    np.testing.assert_array_equal(np.asarray(inverted.get_3d_slice()), raw_np[::-1])
+
+
+def test_invert_scan_direction_deskew_equivalence():
+    # Use an off-centre voxel as an asymmetric feature so errors in
+    # scan-direction inversion (wrong flip direction) are detectable.
+    raw_np = np.zeros((5, 5, 5))
+    raw_np[1, 1, 1] = 10
+
+    def deskew(array: np.ndarray, invert: bool, tmpdir: str) -> np.ndarray:
+        lattice = LatticeData(
+            input_image=DataArray(array, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            invert_scan_direction=invert,
+            save_name="test",
+            save_dir=tmpdir,
+        )
+        return np.asarray(next(iter(lattice.process().slices)).data)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        normal = deskew(raw_np, False, tmpdir)
+        inverted = deskew(raw_np, True, tmpdir)
+        # Inverting the scan direction must equal reversing the raw scan axis then deskewing normally
+        manual = deskew(raw_np[::-1].copy(), False, tmpdir)
+
+    assert inverted.shape == normal.shape
+    np.testing.assert_allclose(inverted, manual)
+    # For an asymmetric input, the flip must actually change the result
+    assert not np.allclose(inverted, normal)
+
+
+def test_invert_scan_direction_display_transform():
+    # "Quick Deskew" display transform (deskew_affine_transform_zyx) must
+    # encode the scan flip, so applying it to  unflipped layer reproduces the
+    # flipped-then-deskewed geometry used by the actual processing/preview output.
+    from lls_core.models.deskew import DeskewParams
+
+    raw_np = np.zeros((6, 6, 6))
+    raw_np[1, 2, 3] = 10
+    raw = DataArray(raw_np, dims=["Z", "Y", "X"])
+    nz = raw_np.shape[0]
+
+    normal = DeskewParams(input_image=raw, physical_pixel_sizes=(1, 1, 1))
+    inverted = DeskewParams(input_image=raw, physical_pixel_sizes=(1, 1, 1), invert_scan_direction=True)
+
+    m = np.asarray(normal.derived.deskew_affine_transform_zyx)
+    m_flipped = np.asarray(inverted.derived.deskew_affine_transform_zyx)
+
+    # Applying the folded transform to a raw coordinate must match applying the standard
+    # transform to the scan-reversed coordinate (z -> nz - 1 - z)
+    for z, y, x in [(0, 0, 0), (1, 2, 3), (5, 4, 1)]:
+        folded = m_flipped @ np.array([z, y, x, 1.0])
+        reference = m @ np.array([nz - 1 - z, y, x, 1.0])
+        np.testing.assert_allclose(folded, reference)
+
+    # With the flag off, the display transform must be untouched
+    np.testing.assert_allclose(
+        m, np.asarray(DeskewParams(input_image=raw, physical_pixel_sizes=(1, 1, 1)).derived.deskew_affine_transform_zyx)
+    )
+
+
+def test_invert_scan_direction_crop_equivalence():
+    # Cropping is performed in deskewed space and mapped back to the (flipped) raw,
+    # so an inverted-scan crop must match cropping a manually-flipped raw volume.
+    from lls_core.models.crop import CropParams
+
+    raw_np = np.zeros((5, 5, 5))
+    raw_np[1, 1, 1] = 10
+    # A generous ROI (clipped to bounds) that covers the deskewed plane
+    roi = [[[0, 0], [0, 100], [100, 100], [100, 0]]]
+
+    def crop_deskew(array: np.ndarray, invert: bool, nz: int, tmpdir: str) -> np.ndarray:
+        lattice = LatticeData(
+            input_image=DataArray(array, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            invert_scan_direction=invert,
+            crop=CropParams(roi_list=roi, z_range=(0, nz)),
+            save_name="test",
+            save_dir=tmpdir,
+        )
+        return np.asarray(next(iter(lattice.process().slices)).data)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nz = LatticeData(
+            input_image=DataArray(raw_np, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            save_name="test",
+            save_dir=tmpdir,
+        ).derived.deskew_vol_shape[0]
+
+        inverted = crop_deskew(raw_np, True, nz, tmpdir)
+        manual = crop_deskew(raw_np[::-1].copy(), False, nz, tmpdir)
+
+    np.testing.assert_allclose(inverted, manual)
+
+
+def test_invert_scan_direction_workflow_path():
+    # The workflow path processes per-slice sub-lattices built by `iter_sublattices`.
+    # `slice_data` already bakes the scan flip into each sub-lattice's input, so the
+    # sub-lattice must NOT flip again (a double flip would cancel out). This guards the
+    # `invert_scan_direction=False` reset in `iter_sublattices` against regressions.
+    raw_np = np.zeros((5, 5, 5))
+    raw_np[1, 1, 1] = 10
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = LatticeData(
+            input_image=DataArray(raw_np, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            invert_scan_direction=True,
+            save_name="test",
+            save_dir=tmpdir,
+        )
+        # Direct processing flips exactly once
+        direct = np.asarray(next(iter(lattice.process().slices)).data)
+        # Each sub-lattice already holds flipped data; processing it must flip once total
+        sublattice = next(iter(lattice.iter_sublattices()))
+        assert sublattice.data.invert_scan_direction is False
+        via_workflow = np.asarray(next(iter(sublattice.data.process().slices)).data)
+
+    np.testing.assert_allclose(via_workflow, direct)
+def test_invert_scan_direction_crop_workflow_path():
+    # Crop + flip + workflow exercised together. The workflow path copies BOTH the crop
+    # and the (reset) invert flag into each sub-lattice via `iter_sublattices`, so the scan
+    # flip must still be applied exactly once end-to-end. Inverting the scan must equal
+    # reversing the raw scan axis manually and processing the same crop workflow normally.
+    from pathlib import Path
+    from lls_core.models.crop import CropParams
+
+    workflow_path = Path(__file__).parent / "workflows" / "binarisation" / "workflow.yml"
+
+    # Asymmetric slab, bright enough to survive the binarisation workflow threshold
+    raw_np = np.zeros((20, 30, 30))
+    raw_np[3:12, 6:22, 6:22] = 500
+
+    def crop_workflow(array: np.ndarray, invert: bool, shape: tuple, tmpdir: str) -> np.ndarray:
+        nz, yd, xd = shape
+        lattice = LatticeData(
+            input_image=DataArray(array, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            invert_scan_direction=invert,
+            crop=CropParams(roi_list=[[[0, 0], [0, xd], [yd, xd], [yd, 0]]], z_range=(0, nz)),
+            workflow=str(workflow_path),
+            save_name="test",
+            save_dir=tmpdir,
+        )
+        return np.asarray(list(lattice.process_workflow().roi_previews())[0])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shape = LatticeData(
+            input_image=DataArray(raw_np, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            save_name="test",
+            save_dir=tmpdir,
+        ).derived.deskew_vol_shape
+
+        inverted = crop_workflow(raw_np, True, shape, tmpdir)
+        manual = crop_workflow(raw_np[::-1].copy(), False, shape, tmpdir)
+        not_inverted = crop_workflow(raw_np, False, shape, tmpdir)
+
+    # The flipped crop workflow must match cropping a manually-reversed raw volume
+    np.testing.assert_allclose(inverted, manual)
+    # The workflow must actually produce content (otherwise the comparison is vacuous)
+    assert (inverted > 0).any()
+    # A double flip in the sub-lattice path would make this equal to the un-inverted result
+    assert not np.allclose(inverted, not_inverted)
+

--- a/plugin/napari_lattice/dock_widget.py
+++ b/plugin/napari_lattice/dock_widget.py
@@ -58,6 +58,7 @@ class LLSZWidget(MagicTemplate):
             angle=deskew_args["angle"],
             physical_pixel_sizes=deskew_args["physical_pixel_sizes"],
             skew=deskew_args["skew"],
+            invert_scan_direction=deskew_args["invert_scan_direction"],
 
             # Output
             channel_range=output_args.channel_range,

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -238,6 +238,7 @@ class DeskewFields(NapariFieldGroup):
         else:
             raise Exception("Only 3-5 dimensional arrays are supported")
 
+    # --- Input / interpretation ---
     img_layer = field(List[Image], widget_type='Select').with_options(
         label="Image Layer(s) to Deskew",
         tooltip="All the image layers you select will be stacked into one image and then deskewed. To select multiple layers, hold Command (MacOS) or Control (Windows, Linux)."
@@ -251,21 +252,6 @@ class DeskewFields(NapariFieldGroup):
         tooltip="The direction along which to stack multiple selected layers.",
         value=StackAlong.CHANNEL
     )
-    pixel_sizes_source = field(PixelSizeSource.Metadata, widget_type="RadioButtons").with_options(label="Pixel Size Source", orientation="horizontal").with_choices([it.value for it in PixelSizeSource])
-    pixel_sizes = field(Tuple[float, float, float]).with_options(
-        label="Pixel Sizes: XYZ (µm)",
-        tooltip="The size of each pixel in microns. The first field selects the X pixel size, then Y, then Z."
-    )
-    angle = field(LatticeData.get_default("angle")).with_options(
-        value=LatticeData.get_default("angle"),
-        label="Skew Angle (°)",
-        tooltip="The angle to deskew the image, in degrees"
-    )
-    device = field(str).with_choices(cle.available_device_names()).with_options(
-        label="Graphics Device",
-        tooltip="The GPU that will be used to perform the processing"
-    )
-    # merge_all_channels = field(False).with_options(label="Merge all Channels")
     dimension_order = field(
         str
     ).with_choices(
@@ -275,10 +261,22 @@ class DeskewFields(NapariFieldGroup):
         tooltip="Specifies the order of dimensions in the input images. For example, if your image is a 4D array with multiple channels along the first axis, you will specify CZYX.",
         value="Get from Metadata"
     )
+    pixel_sizes_source = field(PixelSizeSource.Metadata, widget_type="RadioButtons").with_options(label="Pixel Size Source", orientation="horizontal").with_choices([it.value for it in PixelSizeSource])
+    pixel_sizes = field(Tuple[float, float, float]).with_options(
+        label="Pixel Sizes: XYZ (µm)",
+        tooltip="The size of each pixel in microns. The first field selects the X pixel size, then Y, then Z."
+    )
+
+    # --- Skew geometry ---
     skew_dir = field(DeskewDirection.Y, widget_type="RadioButtons").with_options(
         label="Skew Direction",
         tooltip="The axis along which to deskew",
         orientation="horizontal"
+    )
+    angle = field(LatticeData.get_default("angle")).with_options(
+        value=LatticeData.get_default("angle"),
+        label="Skew Angle (°)",
+        tooltip="The angle to deskew the image, in degrees"
     )
     invert_scan_direction = field(DeskewParams.get_default("invert_scan_direction")).with_options(
         label="Invert Scan Direction",
@@ -286,6 +284,13 @@ class DeskewFields(NapariFieldGroup):
                 "Enable this for microscopes whose scan direction can be reversed.\n"
                 "Leaving it False preserves original behaviour compatible with Zeiss LLS."
     )
+
+    # --- Processing / preview ---
+    device = field(str).with_choices(cle.available_device_names()).with_options(
+        label="Graphics Device",
+        tooltip="The GPU that will be used to perform the processing"
+    )
+    # merge_all_channels = field(False).with_options(label="Merge all Channels")
     quick_deskew = field(False).with_options(
         label="Quick Deskew",
         tooltip = "View the deskewed image. This does NOT generate a new image, but instead transforms\nthe current image in the viewer. Use `Preview` to generate a new image.")

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -217,6 +217,7 @@ class NapariFieldGroup(MagicTemplate):
 class DeskewKwargs(NapariImageParams):
     angle: float
     skew: DeskewDirection
+    invert_scan_direction: bool
 
 @magicclass
 class DeskewFields(NapariFieldGroup):
@@ -278,6 +279,12 @@ class DeskewFields(NapariFieldGroup):
         label="Skew Direction",
         tooltip="The axis along which to deskew",
         orientation="horizontal"
+    )
+    invert_scan_direction = field(DeskewParams.get_default("invert_scan_direction")).with_options(
+        label="Invert Scan Direction",
+        tooltip="Reverse the order of planes along the scan (Z) axis before deskewing.\n"
+                "Enable this for microscopes whose scan direction can be reversed.\n"
+                "Leaving it False preserves original behaviour compatible with Zeiss LLS."
     )
     quick_deskew = field(False).with_options(
         label="Quick Deskew",
@@ -345,11 +352,13 @@ class DeskewFields(NapariFieldGroup):
     @quick_deskew.connect
     @skew_dir.connect #when deskewing parameters change
     @angle.connect
+    @invert_scan_direction.connect
     @pixel_sizes_source.connect
     @pixel_sizes.connect
     def _quick_deskew(self):
         image: Image
-        #Apply quick deskew where image is displayed in canvas as deskewed. 
+        import numpy as np
+        #Apply quick deskew where image is displayed in canvas as deskewed.
         #get value of quick deskew
         quick_deskew = self.quick_deskew.value
         #If quick deskew is True
@@ -385,9 +394,21 @@ class DeskewFields(NapariFieldGroup):
             ndim_display = 2
 
         #transform each image layer selected
+        invert_raw_view = affine_transform is None and self.invert_scan_direction.value
         for image in self.img_layer.value:
             #we do not inverse transform as napari goes from input to output space
-            image.affine = affine_transform
+            if invert_raw_view:
+                # Quick Deskew is off but the scan direction is inverted: give visual
+                # feedback by showing the raw layer with its scan (Z) axis reversed,
+                # without switching to a 3D view. This mirrors the flip that processing
+                # applies. The reflection is in data-index space (z -> nz - 1 - z).
+                nz = image.data.shape[-3]
+                layer_affine = np.eye(4)
+                layer_affine[0, 0] = -1
+                layer_affine[0, 3] = nz - 1
+                image.affine = layer_affine
+            else:
+                image.affine = affine_transform
             image.scale = scale
         
         try:
@@ -418,6 +439,7 @@ class DeskewFields(NapariFieldGroup):
             **params,
             angle=self.angle.value,
             skew = self.skew_dir.value,
+            invert_scan_direction=self.invert_scan_direction.value,
         )
 
     def _make_model(self) -> DeskewParams:
@@ -427,6 +449,7 @@ class DeskewFields(NapariFieldGroup):
             physical_pixel_sizes=kwargs["physical_pixel_sizes"],
             angle=kwargs["angle"],
             skew = kwargs["skew"],
+            invert_scan_direction=kwargs["invert_scan_direction"],
         )
 
 @magicclass


### PR DESCRIPTION
PR introduces a new `invert_scan_direction` option to the deskewing workflow, allowing users to reverse the scan (Z) axis before deskewing. This is essential for supporting OPM scopes different scan directions. 

It is added in CLI and in napari GUI.

The most important changes are:

**Core functionality and models:**

* Added an `invert_scan_direction` boolean field to `DeskewParams` and implemented the logic to reverse the scan (Z) axis in the `apply_scan_flip` method. This flip is applied before deskewing and is reflected in the displayed RAW image to ensure visual consistency

* Updated `LatticeData.slice_data` and related methods to apply the scan flip. Importantly, made sure that sub-lattices do not reapply the flip by resetting the flag in `iter_sublattices`.

**Command-line and parameter handling:**

* Added the `invert_scan_direction` argument to the CLI (`core/lls_core/cmds/__main__.py`) and ensured it is mapped and parsed correctly. 

**Napari GUI integration:**

* Exposed the `invert_scan_direction` option in the Napari plugin UI, connected it to the deskewing logic, and updated the quick deskew display to visually reflect the flip when enabled.

**Testing:**

* Added tests to validate the scan direction inversion, equivalence with manual flipping, correct cropping, display transform correctness, and to guard against double-flipping in workflow paths. They seem like a lot but had to ensure it doesn't affect downstream functionality.