### PR TITLE
Fix  ROI cropping in `crop_volume_deskew` with large OPM data

### DIFF
--- a/core/lls_core/llsz_core.py
+++ b/core/lls_core/llsz_core.py
@@ -178,15 +178,6 @@ def crop_volume_deskew(
     # clip to z bounds of original volume
     z_end_vol = np.clip(z_end_vol_prelim, 0, orig_img_shape[2])
 
-    # If the coordinates are out of bound, then the final volume needs adjustment in Y axis
-    # if skew in X direction, then use y axis for finding correction factor instead
-    if z_end_vol_prelim != z_end_vol:
-        out_bounds_correction = z_end_vol_prelim - z_end_vol
-    elif z_start_vol_prelim != z_start_vol:
-        out_bounds_correction = z_start_vol_prelim - z_start_vol
-    else:
-        out_bounds_correction = 0
-
     # make sure z_start < z_end
     if z_start_vol > z_end_vol:
         # tuple swap  #https://docs.python.org/3/reference/expressions.html#evaluation-order
@@ -264,38 +255,41 @@ def crop_volume_deskew(
             deskew_direction=skew_dir,
         )
 
-    # The height of deskewed_prelim will be larger than specified shape
-    # as the coordinates of the ROI are skewed in the original volume
-    # IF CLIPPING HAPPENS FOR Y_START or Y_END, use difference to calculate offset
-    if skew_dir == DeskewDirection.Y:
-        deskewed_height = deskewed_prelim.shape[1]
-        crop_height = crop_vol_shape[1]
+    # deskewed_prelim is larger than the crop (the shear adds empty wedges), and
+    # its row/col 0 is the MINIMUM deskewed coordinate of the clipped sub-block,
+    # so crop_excess = round(ROI_origin - that_minimum). Old code assumed 
+    # ROI was centred ((deskewed_dim - crop_dim) / 2 + an out-of-bounds fudge),
+    # which only holds at scan-centre and mis-placed off-centre ROIs. 
+    # This was not the case with larger datasets where ROIs were far away from scan centre,
+    # Projecting the clipped corners through the raw->deskewed transform is exact.
+    deskewed_prelim = np.asarray(deskewed_prelim)
+    full_deskew_matrix = np.linalg.inv(reverse_aff._matrix)  # get aff matrix for raw->deskewed, incl. translation
+    # get the 8 ROI box corners in raw space: same corners as calculate_crop_bbox
+    # but clipped to the volume, in xyz order with a homogeneous 1
+    from itertools import product
 
-        # Find "excess" volume on both sides due to deskewing
-        crop_excess: int = max(
-            int(round((deskewed_height - crop_height) / 2)) + out_bounds_correction,
-            0
-        )
-        # Crop in Y
-        deskewed_prelim = np.asarray(deskewed_prelim)
-        deskewed_crop = deskewed_prelim[
-            :, crop_excess : crop_height + crop_excess, :
-        ]
-    # IF CLIPPING HAPPENS FOR X_START or X_END, use difference to calculate offset
+    sub_corners = np.asarray([
+        [x, y, z, 1]
+        for x, y, z in product((x_start, x_end), (y_start, y_end), (z_start_vol, z_end_vol))
+    ])
+    prelim_corners = (full_deskew_matrix @ sub_corners.T).T  # deskewed xyz of sub-block corners
+    roi_origin = np.asarray(crop_bounding_box).min(axis=0)   # [x, y, z, 1]
+
+    if skew_dir == DeskewDirection.Y:
+        crop_height = crop_vol_shape[1]
+        crop_excess: int = max(int(round(roi_origin[1] - prelim_corners[:, 1].min())), 0)
+        deskewed_crop = deskewed_prelim[:, crop_excess : crop_height + crop_excess, :]
+        # Pad the skew axis if the prelim is short near the far field edge
+        if deskewed_crop.shape[1] < crop_height:
+            pad = crop_height - deskewed_crop.shape[1]
+            deskewed_crop = np.pad(deskewed_crop, ((0, 0), (0, pad), (0, 0)))
     elif skew_dir == DeskewDirection.X:
-        deskewed_width = deskewed_prelim.shape[2]
         crop_width = crop_vol_shape[2]
-        
-        # Find "excess" volume on both sides due to deskewing
-        crop_excess = max(
-            int(round((deskewed_width - crop_width) / 2)) + out_bounds_correction,
-            0
-        )
-        # Crop in X
-        deskewed_prelim = np.asarray(deskewed_prelim)
-        deskewed_crop = deskewed_prelim[
-            :, :, crop_excess : crop_width + crop_excess
-        ]
+        crop_excess = max(int(round(roi_origin[0] - prelim_corners[:, 0].min())), 0)
+        deskewed_crop = deskewed_prelim[:, :, crop_excess : crop_width + crop_excess]
+        if deskewed_crop.shape[2] < crop_width:
+            pad = crop_width - deskewed_crop.shape[2]
+            deskewed_crop = np.pad(deskewed_crop, ((0, 0), (0, 0), (0, pad)))
 
     # For debugging, ,deskewed_prelim will also be returned which is the uncropped volume
     if debug:

--- a/core/tests/test_crop_placement.py
+++ b/core/tests/test_crop_placement.py
@@ -1,0 +1,63 @@
+"""Regression test for crop_volume_deskew ROI placement.
+
+Verifies that ROI crops match the same region sliced from the full deskewed
+volume at low, centre, and high positions, catching the off-centre trim bug.
+
+The error is invisible on narrow-FOV data (e.g.
+the 5x5x5 volume in ``test_crop_deskew.py``, which is firmly in the near-zero
+regime) but grows with the lateral field width.
+"""
+import numpy as np
+import pytest
+import pyclesperanto_prototype as cle
+
+from lls_core.llsz_core import crop_volume_deskew
+from lls_core import DeskewDirection
+
+
+def _raw():
+    # Uniform background + a few off-centre markers. The deskew shear spreads each
+    # marker across the skew axis, so every ROI position contains discriminating
+    # structure (guarded below via gt.std()).
+    r = np.full((150, 400, 120), 30.0, np.float32)
+    for z, y in [(30, 80), (75, 200), (120, 330)]:
+        r[z - 3:z + 3, y - 6:y + 6, 55:65] = 800.0
+    return r
+
+
+@pytest.mark.parametrize("angle", [30.0, 45.0])
+@pytest.mark.parametrize("pos", ["low", "centre", "high"])  # low/high are far from centre
+def test_crop_placement(angle, pos):
+    raw = _raw()
+    full = np.asarray(cle.pull(cle.deskew_y(
+        raw, angle_in_degrees=angle,
+        voxel_size_x=1, voxel_size_y=1, voxel_size_z=1)))
+
+    H = 60
+    frac = {"low": 0.2, "centre": 0.5, "high": 0.8}[pos]
+    y0 = int(np.clip(frac * full.shape[1] - H / 2, 0, full.shape[1] - H))
+    y1 = y0 + H
+    x0 = full.shape[2] // 2 - H // 2
+    x1 = x0 + H
+    roi = [[y0, x0], [y0, x1], [y1, x1], [y1, x0]]
+    gt = full[:, y0:y1, x0:x1]
+
+    # Guard: the ROI must contain varying content, otherwise the comparison below
+    # would be vacuous (a mis-placed crop could match a uniform background).
+    assert gt.std() > 1.0
+
+    crop = np.asarray(crop_volume_deskew(
+        original_volume=raw, roi_shape=[roi], angle_in_degrees=angle,
+        voxel_size_x=1, voxel_size_y=1, voxel_size_z=1,
+        z_start=0, z_end=full.shape[0], skew_dir=DeskewDirection.Y)).astype(np.float32)
+
+    qm = min(crop.shape[0], gt.shape[0])           # deskew Z-depth can differ by 1
+    assert crop.shape[1:] == gt.shape[1:]          # right size (catches empty/short crops)
+    assert np.allclose(crop[:qm], gt[:qm], atol=1e-2)   # right place + right data
+
+    # Stronger placement check: the crop must originate from rows [y0:y1] of the
+    # full deskew, not elsewhere. This is what fails badly for off-centre ROIs.
+    h = crop.shape[1]
+    errs = [float(np.mean(np.abs(full[:qm, k:k + h, x0:x1] - crop[:qm])))
+            for k in range(full.shape[1] - h + 1)]
+    assert abs(int(np.argmin(errs)) - y0) <= 1


### PR DESCRIPTION
### Problem
When cropping, `crop_volume_deskew` deskews only the ROI's raw sub-block into `deskewed_prelim`, which is taller/wider than the ROI because the shear adds empty wedges. The previous code extracted the final crop and trimmed the edges assuming that the ROI sat in the middle of that block:

```python
crop_excess = max(int(round((deskewed_dim - crop_dim) / 2)) + out_bounds_correction, 0)
```

This is only the case if the ROI is somewhat close to scan-centre. The placement error grows with distance from centre and with lateral field width — **≈0 px on narrow-FOV Zeiss LLS data, but +100–265 px on wide OPM data**. The bug is  that cropping on large OPM data returned images far from the defined ROI.

### Fix
Compute the true offset of the ROI instead of guessing it. Forward-project the already-clipped sub-block corners through the full-frame raw→deskewed transform (`inv(reverse_aff._matrix)`) and read where the ROI origin lands relative to the block's first row/column:

```python
crop_excess = max(int(round(roi_origin[axis] - prelim_corners[:, axis].min())), 0)
```

This is exact, and because it uses the clipped corner, the old `out_bounds_correction` is redundant (now removed). 
Zero padding on skew axis makes sure  the output always has the requested crop size at the far edge.

### Tests
- New `core/tests/test_crop_placement.py`: parametrized over angle × ROI position (low/centre/high), asserting the crop matches slicing the ROI directly out of the full deskewed volume, plus a cross-correlation check that the crop originates from the correct rows. The off-centre cases are the discriminating ones.
- Verified: **6/6 new cases fail on the old code, all pass on the fix**; existing `test_crop_deskew` still passes.

### Notes
- Existing `test_crop_deskew` (5×5×5 volume) is in the near-zero regime and cannot catch this bug.
- Used Claude Code for troubleshooting