### PR TITLE
GUI fixes

### DIFF
--- a/plugin/napari_lattice/dock_widget.py
+++ b/plugin/napari_lattice/dock_widget.py
@@ -154,11 +154,13 @@ class LLSZWidget(MagicTemplate):
                 call_button="Preview"
                 )
     @set_design(text="Preview")
+    @thread_worker
     def preview(self, header: str, time: int, channel: int):
         from pathlib import Path
 
-        # We only need to process one time point for the preview, 
-        # so we made a copy using a subset of the times
+        # Runs on a background thread. Compute previews here; add them to the
+        # viewer in the yielded callback (main thread). We only need one time
+        # point for the preview, so we copy a subset of the times.
         lattice = self._make_model(validate=False).copy_validate(update=dict(
             time_range = range(time, time+1),
             channel_range = range(channel, channel+1),
@@ -182,10 +184,25 @@ class LLSZWidget(MagicTemplate):
         else:
             previews = lattice.process_workflow().roi_previews()
 
+        # Yield each ROI as it is computed so images appear incrementally.
         for preview in previews:
-            self.parent_viewer.add_image(preview, scale=scale, name="Napari Lattice Preview")
-            max_z = np.argmax(np.sum(preview, axis=(1, 2)))
-            self.parent_viewer.dims.set_current_step(0, max_z)
+            yield (preview, scale)
+
+    @preview.started.connect
+    def _preview_started(self):
+        self._set_run_buttons_enabled(False)
+
+    @preview.yielded.connect
+    def _preview_yielded(self, result):
+        # Main thread: safe to touch the viewer here.
+        preview, scale = result
+        self.parent_viewer.add_image(preview, scale=scale, name="Napari Lattice Preview")
+        max_z = np.argmax(np.sum(preview, axis=(1, 2)))
+        self.parent_viewer.dims.set_current_step(0, max_z)
+
+    @preview.finished.connect
+    def _preview_finished(self):
+        self._set_run_buttons_enabled(True)
 
 
     @set_design(text="Save")

--- a/plugin/napari_lattice/dock_widget.py
+++ b/plugin/napari_lattice/dock_widget.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from lls_core.models.lattice_data import LatticeData
 from magicclass import MagicTemplate, field, magicclass, set_options, vfield
+from magicclass.utils import thread_worker
 from magicclass.wrappers import set_design
 from napari_lattice.fields import (
     CroppingFields,
@@ -27,6 +28,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+# Show background-worker progress in napari's activity dock rather than a
+# separate popup window. This is a process-global default for magicclass
+# thread workers; napari-lattice is the only in-process consumer.
+thread_worker.set_default("napari")
+
 @magicclass(widget_type="split")
 class LLSZWidget(MagicTemplate):
     def __post_init__(self):
@@ -43,6 +49,15 @@ class LLSZWidget(MagicTemplate):
             return True
         except:
             return False
+
+    def _set_run_buttons_enabled(self, enabled: bool) -> None:
+        """
+        Enable/disable the Save and Preview call buttons so a second run cannot be
+        launched while one is already active. Called from worker started/finished
+        callbacks (main thread).
+        """
+        self["save"].enabled = enabled
+        self["preview"].enabled = enabled
 
     def _make_model(self, validate: bool = True) -> LatticeData:
         from rich import print
@@ -174,11 +189,27 @@ class LLSZWidget(MagicTemplate):
 
 
     @set_design(text="Save")
+    @thread_worker(progress={"desc": "Deskewing…"})
     def save(self):
-        from napari.utils.notifications import show_info
+        # Runs on a background thread. _make_model() snapshots the current GUI
+        # state into a LatticeData; lattice.save() runs the (untouched) serial or
+        # parallel-ROI save path. No napari calls here.
         lattice = self._make_model()
         lattice.save()
-        show_info(f"Deskewing successfuly completed. Results are located in {lattice.save_dir}")
+        return lattice.save_dir
+
+    @save.started.connect
+    def _save_started(self):
+        self._set_run_buttons_enabled(False)
+
+    @save.returned.connect
+    def _save_returned(self, save_dir):
+        from napari.utils.notifications import show_info
+        show_info(f"Deskewing successfuly completed. Results are located in {save_dir}")
+
+    @save.finished.connect
+    def _save_finished(self):
+        self._set_run_buttons_enabled(True)
 
     def _get_fields(self) -> Iterable[NapariFieldGroup]:
         """Yields all the child Field classes which inherit from NapariFieldGroup"""

--- a/plugin/napari_lattice/dock_widget.py
+++ b/plugin/napari_lattice/dock_widget.py
@@ -7,7 +7,9 @@ import numpy as np
 from lls_core.models.lattice_data import LatticeData
 from magicclass import MagicTemplate, field, magicclass, set_options, vfield
 from magicclass.utils import thread_worker
+from magicclass.widgets import Label
 from magicclass.wrappers import set_design
+from magicgui.widgets import ProgressBar
 from napari_lattice.fields import (
     CroppingFields,
     DeconvolutionFields,
@@ -28,16 +30,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Show background-worker progress in napari's activity dock rather than a
-# separate popup window. This is a process-global default for magicclass
-# thread workers; napari-lattice is the only in-process consumer.
-thread_worker.set_default("napari")
-
 @magicclass(widget_type="split")
 class LLSZWidget(MagicTemplate):
     def __post_init__(self):
         # aligning collapsible widgets at the top instead of having them centered vertically
         self._widget._layout.setAlignment(Qt.AlignTop)
+        self.save_progress_hint.value = "See the terminal for detailed progress."
 
 
     def _check_validity(self) -> bool:
@@ -205,18 +203,40 @@ class LLSZWidget(MagicTemplate):
         self._set_run_buttons_enabled(True)
 
 
+    # Indeterminate "Processing…" bar shown inside this panel (not the napari
+    # activity dock) while a save runs. max=0 makes Qt render a self-animating
+    # busy bar that needs no per-step updates; the save worker never touches it,
+    # so there is nothing to marshal across threads. Hidden until a save starts.
+    save_progress = field(ProgressBar).with_options(
+        label="Processing…",
+        visible=False,
+        max=0,
+    )
+    # Sits under the busy bar and points the user to the terminal, where lls_core
+    # prints the detailed per-timepoint/channel tqdm progress. Shown/hidden with it.
+    # Text is set in __post_init__ (Label ignores an initial value via with_options).
+    save_progress_hint = field(Label).with_options(
+        label="",
+        visible=False,
+    )
+
     @set_design(text="Save")
-    @thread_worker(progress={"desc": "Deskewing…"})
+    @thread_worker
     def save(self):
         # Runs on a background thread. _make_model() snapshots the current GUI
-        # state into a LatticeData; lattice.save() runs the (untouched) serial or
-        # parallel-ROI save path. No napari calls here.
+        # state into a LatticeData; lattice.save() runs the serial or parallel-ROI
+        # save path. The GUI "still working" cue is the in-panel save_progress
+        # bar (toggled in _save_started/_save_finished); the detailed per-timepoint
+        # progress is the tqdm bars lls_core prints to the terminal. No napari
+        # calls here.
         lattice = self._make_model()
         lattice.save()
         return lattice.save_dir
 
     @save.started.connect
     def _save_started(self):
+        self.save_progress.visible = True
+        self.save_progress_hint.visible = True
         self._set_run_buttons_enabled(False)
 
     @save.returned.connect
@@ -226,6 +246,8 @@ class LLSZWidget(MagicTemplate):
 
     @save.finished.connect
     def _save_finished(self):
+        self.save_progress.visible = False
+        self.save_progress_hint.visible = False
         self._set_run_buttons_enabled(True)
 
     def _get_fields(self) -> Iterable[NapariFieldGroup]:

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -326,9 +326,13 @@ class DeskewFields(NapariFieldGroup):
         # Recalculate the dimension options whenever the image changes
         self.dimension_order.reset_choices()
 
+    @quick_deskew.connect
     @pixel_sizes_source.connect
     @pixel_sizes.connect
     def _rescale_image(self):
+        # Also fires when Quick Deskew is toggled: when it is turned OFF this
+        # restores the raw-view scale (the `not quick_deskew` guard below no-ops
+        # the ON case, where _quick_deskew owns the scale instead).
         # Whenever the pixel sizes are changed, this should be reflected in the viewer
         image: Image
         from napari_lattice.utils import get_viewer, apply_layer_transform
@@ -460,12 +464,29 @@ class DeskewFields(NapariFieldGroup):
         The inputs that the reader output (`lattice_params_from_napari`) actually
         depends on. Deliberately excludes the deskew scalars (angle/skew/invert/
         coverslip), which do NOT change the concatenated image — so tweaking them
-        can reuse a cached reader result instead of re-running the concat. Layers
-        are keyed by identity (`id`) since they are unhashable and we only care
-        about the exact selection.
+        can reuse a cached reader result instead of re-running the concat.
+
+        Each layer is keyed by *content*, not just ``id(layer)``: the cache does
+        not keep the layer objects alive, so a bare ``id`` could be reused by a
+        later object (open file A, close it, open file B) and false-hit. Including
+        ``id(data)``, the data shape, the name and the source path makes a false
+        hit require a simultaneous double address-reuse (layer AND its array) —
+        practically impossible — and picks up renames (which affect save_name)
+        and per-layer metadata pixel sizes (distinct paths -> distinct keys).
         """
+        def layer_key(layer):
+            source = getattr(layer, "source", None)
+            path = getattr(source, "path", None) if source is not None else None
+            data = getattr(layer, "data", None)
+            return (
+                id(layer),
+                id(data),
+                tuple(getattr(data, "shape", ()) or ()),
+                getattr(layer, "name", None),
+                str(path) if path is not None else None,
+            )
         return (
-            tuple(id(layer) for layer in self.img_layer.value),
+            tuple(layer_key(layer) for layer in self.img_layer.value),
             self.dimension_order.value,
             self.pixel_sizes_source.value,
             tuple(self.pixel_sizes.value),

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -387,6 +387,11 @@ class DeskewFields(NapariFieldGroup):
     def _quick_deskew(self):
         image: Image
         import numpy as np
+        # Nothing to transform if no image layers are selected (e.g. the user
+        # deleted the layer(s) mid-save). Exit before building the model,
+        # otehrwise an error is raised on an empty layer
+        if not self.img_layer.value:
+            return
         #Apply quick deskew where image is displayed in canvas as deskewed.
         #get value of quick deskew
         quick_deskew = self.quick_deskew.value

--- a/plugin/napari_lattice/reader.py
+++ b/plugin/napari_lattice/reader.py
@@ -209,9 +209,33 @@ def bdv_h5_reader(path):
     layer_type = "image"  # optional, default is "image"
     return [(images, add_kwargs, layer_type)]
 
+# Per-layer RAM budget (MB) for caching recently-viewed (T,C) ZYX stacks so that
+# re-slicing the same plane (scale/affine tweaks) and scrolling Z within a
+# timepoint are instant instead of ~130 ms. The number of stacks cached is
+# derived from this budget and the actual stack size, so memory stays bounded
+# regardless of file size (a fixed stack *count* would balloon on large volumes
+# and under-cache small ones). Override per session with
+# NAPARI_LATTICE_CZI_CACHE_MB (0 disables caching).
+_FAST_CZI_CACHE_MB_DEFAULT = 512.0
+# Hard cap so tiny volumes don't cache an absurd number of stacks.
+_FAST_CZI_CACHE_MAX_STACKS = 32
+
+
+def _fast_czi_cache_stacks(stack_bytes: int) -> int:
+    """Number of (T,C) stacks to cache for a given per-stack byte size."""
+    try:
+        budget_mb = float(os.environ.get("NAPARI_LATTICE_CZI_CACHE_MB", _FAST_CZI_CACHE_MB_DEFAULT))
+    except (TypeError, ValueError):
+        budget_mb = _FAST_CZI_CACHE_MB_DEFAULT
+    budget = int(max(0.0, budget_mb) * 1024 * 1024)
+    if budget <= 0:
+        return 0  # lru_cache(maxsize=0) -> caching disabled
+    return int(max(1, min(_FAST_CZI_CACHE_MAX_STACKS, budget // max(stack_bytes, 1))))
+
+
 def _czi_fast_dask_data(path: str, image: BioImage):
     """
-    Build a lazily-read dask array for a (non-mosaic) CZI, chunked per T,C via
+    Build a lazily-read dask array for a (non-mosaic) CZI, chunked per (T, C) via
     single bulk ``aicspylibczi`` reads. Multi-scene CZIs are supported: the
     caller iterates scenes and calls this once per scene, so we read the scene
     bioio currently has selected (``image.current_scene_index``) via the S index.
@@ -219,21 +243,24 @@ def _czi_fast_dask_data(path: str, image: BioImage):
     Why: bioio's ``dask_data`` chunks the volume per Z-plane, producing tens of
     thousands of tiny chunks. Slicing a single plane in napari then pays dask
     graph overhead proportional to the whole chunk count (~9 s on a 20 GB CZI),
-    even though the underlying CZI read is ~40 ms on an SSD. Reading a whole T,C
-    ZYX stack in one single call collapses the graph (T*C chunks) and reads in
-    ~130 ms. Keeps it fully lazy: only displayed time,channel is read.
-    Key point: Rechunking bioio's dask_data was not helping, as
-    coarse chunk still assembled from the same slow per-plane reads.
+    even though the underlying CZI read is ~40 ms on an SSD. Reading a whole
+    (T, C) ZYX stack in one call collapses the graph (T*C chunks) and reads in
+    ~130 ms. Still fully lazy: only the displayed (time, channel) is read.
+    Rechunking bioio's ``dask_data`` does NOT help — the coarse chunk is still
+    assembled from the same slow per-plane reads.
 
-    For multi-scene files (untested in CI) the result is checked one plane
-    against bioio before being trusted; on any mismatch we return ``None`` so the
-    caller falls back to bioio's (slow but correct) ``dask_data``.
+    Correctness safeguards: the plain single-scene, no-extra-dimension path is
+    verified byte-identical to bioio. Every other path (multi-scene S-index
+    alignment, exotic non-ZYX dimensions) is validated against bioio on a
+    mid-stack plane before being trusted; on any mismatch or read error we return
+    ``None`` so the caller falls back to bioio's slow-but-correct ``dask_data``.
     """
     if not str(path).lower().endswith(".czi"):
         return None
     try:
         from aicspylibczi import CziFile
         import threading
+        from functools import lru_cache
         from dask import delayed as _delayed
     except Exception:
         return None
@@ -242,9 +269,12 @@ def _czi_fast_dask_data(path: str, image: BioImage):
         czi = CziFile(str(path))
         if czi.is_mosaic():
             return None
-        dims_shape = czi.get_dims_shape()[0]
-        n_scenes = dims_shape.get("S", (0, 1))[1]
-        # The scene bioio currently has selected (0 for single-scene files).
+        present_dims = set(czi.get_dims_shape()[0].keys())
+        # Scene count from bioio (authoritative and matching the caller's scene
+        # loop). Deriving it from block 0's "S" entry undercounts *ragged*
+        # multi-scene CZIs (get_dims_shape returns one dict per scene), which
+        # would skip the S index and the self-check -> silently read scene 0.
+        n_scenes = max(len(getattr(image, "scenes", None) or [None]), 1)
         scene_idx = int(getattr(image, "current_scene_index", 0) or 0)
     except Exception:
         return None
@@ -258,13 +288,38 @@ def _czi_fast_dask_data(path: str, image: BioImage):
     Z, Y, X = sizes["Z"], sizes["Y"], sizes["X"]
     nT, nC = sizes.get("T", 1), sizes.get("C", 1)
 
-    # aicspylibczi's reader is not guaranteed thread-safe; napari slices on
-    # worker threads, so serialise reads. Each read is fast (~130 ms).
+    # Any CZI dimension other than Z,Y,X (and the T,C,S we index explicitly) must
+    # be constrained, else aicspylibczi returns it at full size and reshape(Z,Y,X)
+    # would raise on a dask worker at slice time instead of falling back here.
+    has_T, has_C, has_S = "T" in present_dims, "C" in present_dims, "S" in present_dims
+    extra_dims = [d for d in present_dims if d not in ("X", "Y", "Z", "T", "C", "S")]
+
+    # aicspylibczi's reader is not guaranteed thread-safe; napari slices on worker
+    # threads, so serialise reads. The bounded LRU keeps the most-recently viewed
+    # (T,C) stacks resident so repeated slices of the same plane are instant;
+    # the stack count is derived from a RAM budget and this file's stack size.
+    #
+    # NOTE: this closure captures `lock` (and `czi`), which are not picklable, so
+    # the array must only be computed under dask's in-process THREADED scheduler
+    # (napari's default). It is never sent to another process here: parallel ROI
+    # processing re-opens the file from `input_image_path` in each worker (see
+    # lls_core.models.lattice_data._dispatch_payload) rather than pickling this
+    # array. Computing it under the `processes`/`distributed` scheduler would fail
+    # to pickle the lock.
     lock = threading.Lock()
+    stack_bytes = int(Z) * int(Y) * int(X) * np.dtype(dtype).itemsize
+
+    @lru_cache(maxsize=_fast_czi_cache_stacks(stack_bytes))
     def read_stack(t: int, c: int) -> np.ndarray:
-        kwargs = {"T": int(t), "C": int(c)}
-        if n_scenes > 1:
+        kwargs = {}
+        if has_T:
+            kwargs["T"] = int(t)
+        if has_C:
+            kwargs["C"] = int(c)
+        if has_S and n_scenes > 1:
             kwargs["S"] = scene_idx
+        for d in extra_dims:
+            kwargs[d] = 0
         with lock:
             arr, _ = czi.read_image(**kwargs)
         return np.asarray(arr).reshape(Z, Y, X)
@@ -293,14 +348,18 @@ def _czi_fast_dask_data(path: str, image: BioImage):
     except Exception:
         return None
 
-    if arr.shape != image.dask_data.shape:
+    if arr.shape != image.dask_data.shape or arr.dtype != image.dask_data.dtype:
         return None
 
-    # Multi-scene is untested in CI: verify one plane matches bioio before
-    # trusting the S-index alignment; fall back to bioio on any mismatch.
-    if n_scenes > 1:
+    # Verified path: single-scene with only standard dimensions. Anything else is
+    # validated against bioio on a MID-stack plane (Z=0 is frequently near-black
+    # and would false-pass a scene-misalignment); mismatch/error -> fall back.
+    if n_scenes > 1 or extra_dims:
         try:
-            probe = tuple(slice(None) if d in ("Y", "X") else 0 for d in order)
+            probe = tuple(
+                slice(None) if d in ("Y", "X") else (sizes[d] // 2 if d == "Z" else 0)
+                for d in order
+            )
             if not np.array_equal(
                 np.asarray(arr[probe].compute()),
                 np.asarray(image.dask_data[probe].compute()),

--- a/plugin/napari_lattice/reader.py
+++ b/plugin/napari_lattice/reader.py
@@ -211,23 +211,20 @@ def bdv_h5_reader(path):
 
 def _czi_fast_dask_data(path: str, image: BioImage):
     """
-    Build a lazily-read dask array for a (non-mosaic) CZI, chunked per T,C via
-    single bulk ``aicspylibczi`` reads. Multi-scene CZIs are supported: the
-    caller iterates scenes and calls this once per scene, so we read the scene
-    bioio currently has selected (``image.current_scene_index``) via the S index.
+    Build a lazily-read dask array for a (non-mosaic, single-scene) CZI, chunked
+    per ``(T, C)`` via single bulk ``aicspylibczi`` reads.
 
     Why: bioio's ``dask_data`` chunks the volume per Z-plane, producing tens of
     thousands of tiny chunks. Slicing a single plane in napari then pays dask
     graph overhead proportional to the whole chunk count (~9 s on a 20 GB CZI),
-    even though the underlying CZI read is ~40 ms on an SSD. Reading a whole T,C
-    ZYX stack in one single call collapses the graph (T*C chunks) and reads in
-    ~130 ms. Keeps it fully lazy: only displayed time,channel is read.
-    Key point: Rechunking bioio's dask_data was not helping, as
-    coarse chunk still assembled from the same slow per-plane reads.
+    even though the underlying CZI read is ~40 ms. Reading a whole ``(T, C)``
+    ZYX stack in one bulk call collapses the graph (T*C chunks) and reads in
+    ~130 ms. Still fully lazy: only the ``(T, C)`` actually displayed is read,
+    never the whole image. Rechunking bioio's ``dask_data`` does NOT help — the
+    coarse chunk is still assembled from the same slow per-plane reads.
 
-    For multi-scene files (untested in CI) the result is checked one plane
-    against bioio before being trusted; on any mismatch we return ``None`` so the
-    caller falls back to bioio's (slow but correct) ``dask_data``.
+    Returns a dask array matching ``image.dims.order``/shape, or ``None`` to fall
+    back to ``image.dask_data`` (non-CZI, mosaic, multi-scene, or any error).
     """
     if not str(path).lower().endswith(".czi"):
         return None
@@ -242,10 +239,10 @@ def _czi_fast_dask_data(path: str, image: BioImage):
         czi = CziFile(str(path))
         if czi.is_mosaic():
             return None
+        # Multi-scene CZIs need an S index we don't thread through here.
         dims_shape = czi.get_dims_shape()[0]
-        n_scenes = dims_shape.get("S", (0, 1))[1]
-        # The scene bioio currently has selected (0 for single-scene files).
-        scene_idx = int(getattr(image, "current_scene_index", 0) or 0)
+        if dims_shape.get("S", (0, 1))[1] > 1:
+            return None
     except Exception:
         return None
 
@@ -262,11 +259,8 @@ def _czi_fast_dask_data(path: str, image: BioImage):
     # worker threads, so serialise reads. Each read is fast (~130 ms).
     lock = threading.Lock()
     def read_stack(t: int, c: int) -> np.ndarray:
-        kwargs = {"T": int(t), "C": int(c)}
-        if n_scenes > 1:
-            kwargs["S"] = scene_idx
         with lock:
-            arr, _ = czi.read_image(**kwargs)
+            arr, _ = czi.read_image(T=int(t), C=int(c))
         return np.asarray(arr).reshape(Z, Y, X)
 
     try:
@@ -295,20 +289,6 @@ def _czi_fast_dask_data(path: str, image: BioImage):
 
     if arr.shape != image.dask_data.shape:
         return None
-
-    # Multi-scene is untested in CI: verify one plane matches bioio before
-    # trusting the S-index alignment; fall back to bioio on any mismatch.
-    if n_scenes > 1:
-        try:
-            probe = tuple(slice(None) if d in ("Y", "X") else 0 for d in order)
-            if not np.array_equal(
-                np.asarray(arr[probe].compute()),
-                np.asarray(image.dask_data[probe].compute()),
-            ):
-                return None
-        except Exception:
-            return None
-
     return arr
 
 

--- a/plugin/napari_lattice/reader.py
+++ b/plugin/napari_lattice/reader.py
@@ -211,20 +211,23 @@ def bdv_h5_reader(path):
 
 def _czi_fast_dask_data(path: str, image: BioImage):
     """
-    Build a lazily-read dask array for a (non-mosaic, single-scene) CZI, chunked
-    per ``(T, C)`` via single bulk ``aicspylibczi`` reads.
+    Build a lazily-read dask array for a (non-mosaic) CZI, chunked per T,C via
+    single bulk ``aicspylibczi`` reads. Multi-scene CZIs are supported: the
+    caller iterates scenes and calls this once per scene, so we read the scene
+    bioio currently has selected (``image.current_scene_index``) via the S index.
 
     Why: bioio's ``dask_data`` chunks the volume per Z-plane, producing tens of
     thousands of tiny chunks. Slicing a single plane in napari then pays dask
     graph overhead proportional to the whole chunk count (~9 s on a 20 GB CZI),
-    even though the underlying CZI read is ~40 ms. Reading a whole ``(T, C)``
-    ZYX stack in one bulk call collapses the graph (T*C chunks) and reads in
-    ~130 ms. Still fully lazy: only the ``(T, C)`` actually displayed is read,
-    never the whole image. Rechunking bioio's ``dask_data`` does NOT help — the
-    coarse chunk is still assembled from the same slow per-plane reads.
+    even though the underlying CZI read is ~40 ms on an SSD. Reading a whole T,C
+    ZYX stack in one single call collapses the graph (T*C chunks) and reads in
+    ~130 ms. Keeps it fully lazy: only displayed time,channel is read.
+    Key point: Rechunking bioio's dask_data was not helping, as
+    coarse chunk still assembled from the same slow per-plane reads.
 
-    Returns a dask array matching ``image.dims.order``/shape, or ``None`` to fall
-    back to ``image.dask_data`` (non-CZI, mosaic, multi-scene, or any error).
+    For multi-scene files (untested in CI) the result is checked one plane
+    against bioio before being trusted; on any mismatch we return ``None`` so the
+    caller falls back to bioio's (slow but correct) ``dask_data``.
     """
     if not str(path).lower().endswith(".czi"):
         return None
@@ -239,10 +242,10 @@ def _czi_fast_dask_data(path: str, image: BioImage):
         czi = CziFile(str(path))
         if czi.is_mosaic():
             return None
-        # Multi-scene CZIs need an S index we don't thread through here.
         dims_shape = czi.get_dims_shape()[0]
-        if dims_shape.get("S", (0, 1))[1] > 1:
-            return None
+        n_scenes = dims_shape.get("S", (0, 1))[1]
+        # The scene bioio currently has selected (0 for single-scene files).
+        scene_idx = int(getattr(image, "current_scene_index", 0) or 0)
     except Exception:
         return None
 
@@ -259,8 +262,11 @@ def _czi_fast_dask_data(path: str, image: BioImage):
     # worker threads, so serialise reads. Each read is fast (~130 ms).
     lock = threading.Lock()
     def read_stack(t: int, c: int) -> np.ndarray:
+        kwargs = {"T": int(t), "C": int(c)}
+        if n_scenes > 1:
+            kwargs["S"] = scene_idx
         with lock:
-            arr, _ = czi.read_image(T=int(t), C=int(c))
+            arr, _ = czi.read_image(**kwargs)
         return np.asarray(arr).reshape(Z, Y, X)
 
     try:
@@ -289,6 +295,20 @@ def _czi_fast_dask_data(path: str, image: BioImage):
 
     if arr.shape != image.dask_data.shape:
         return None
+
+    # Multi-scene is untested in CI: verify one plane matches bioio before
+    # trusting the S-index alignment; fall back to bioio on any mismatch.
+    if n_scenes > 1:
+        try:
+            probe = tuple(slice(None) if d in ("Y", "X") else 0 for d in order)
+            if not np.array_equal(
+                np.asarray(arr[probe].compute()),
+                np.asarray(image.dask_data[probe].compute()),
+            ):
+                return None
+        except Exception:
+            return None
+
     return arr
 
 

--- a/plugin/napari_lattice/reader.py
+++ b/plugin/napari_lattice/reader.py
@@ -209,6 +209,109 @@ def bdv_h5_reader(path):
     layer_type = "image"  # optional, default is "image"
     return [(images, add_kwargs, layer_type)]
 
+def _czi_fast_dask_data(path: str, image: BioImage):
+    """
+    Build a lazily-read dask array for a (non-mosaic) CZI, chunked per T,C via
+    single bulk ``aicspylibczi`` reads. Multi-scene CZIs are supported: the
+    caller iterates scenes and calls this once per scene, so we read the scene
+    bioio currently has selected (``image.current_scene_index``) via the S index.
+
+    Why: bioio's ``dask_data`` chunks the volume per Z-plane, producing tens of
+    thousands of tiny chunks. Slicing a single plane in napari then pays dask
+    graph overhead proportional to the whole chunk count (~9 s on a 20 GB CZI),
+    even though the underlying CZI read is ~40 ms on an SSD. Reading a whole T,C
+    ZYX stack in one single call collapses the graph (T*C chunks) and reads in
+    ~130 ms. Keeps it fully lazy: only displayed time,channel is read.
+    Key point: Rechunking bioio's dask_data was not helping, as
+    coarse chunk still assembled from the same slow per-plane reads.
+
+    For multi-scene files (untested in CI) the result is checked one plane
+    against bioio before being trusted; on any mismatch we return ``None`` so the
+    caller falls back to bioio's (slow but correct) ``dask_data``.
+    """
+    if not str(path).lower().endswith(".czi"):
+        return None
+    try:
+        from aicspylibczi import CziFile
+        import threading
+        from dask import delayed as _delayed
+    except Exception:
+        return None
+
+    try:
+        czi = CziFile(str(path))
+        if czi.is_mosaic():
+            return None
+        dims_shape = czi.get_dims_shape()[0]
+        n_scenes = dims_shape.get("S", (0, 1))[1]
+        # The scene bioio currently has selected (0 for single-scene files).
+        scene_idx = int(getattr(image, "current_scene_index", 0) or 0)
+    except Exception:
+        return None
+
+    order = image.dims.order
+    if not all(d in order for d in ("Z", "Y", "X")):
+        return None
+
+    sizes = dict(zip(order, image.dask_data.shape))
+    dtype = image.dask_data.dtype
+    Z, Y, X = sizes["Z"], sizes["Y"], sizes["X"]
+    nT, nC = sizes.get("T", 1), sizes.get("C", 1)
+
+    # aicspylibczi's reader is not guaranteed thread-safe; napari slices on
+    # worker threads, so serialise reads. Each read is fast (~130 ms).
+    lock = threading.Lock()
+    def read_stack(t: int, c: int) -> np.ndarray:
+        kwargs = {"T": int(t), "C": int(c)}
+        if n_scenes > 1:
+            kwargs["S"] = scene_idx
+        with lock:
+            arr, _ = czi.read_image(**kwargs)
+        return np.asarray(arr).reshape(Z, Y, X)
+
+    try:
+        # Assemble as TCZYX (singleton T/C when absent), then squeeze/transpose
+        # to match the image's actual dimension order.
+        t_blocks = []
+        for t in range(nT):
+            c_blocks = [
+                da.from_delayed(_delayed(read_stack)(t, c), shape=(Z, Y, X), dtype=dtype)
+                for c in range(nC)
+            ]
+            t_blocks.append(da.stack(c_blocks))   # (C, Z, Y, X)
+        arr = da.stack(t_blocks)                  # (T, C, Z, Y, X)
+
+        # Drop singleton T/C axes that aren't in the real order.
+        take = tuple(
+            slice(None) if d in order or d in ("Z", "Y", "X") else 0
+            for d in "TCZYX"
+        )
+        arr = arr[take]
+        present = [d for d in "TCZYX" if d in order]
+        if present != list(order):
+            arr = arr.transpose([present.index(d) for d in order])
+    except Exception:
+        return None
+
+    if arr.shape != image.dask_data.shape:
+        return None
+
+    # Multi-scene is untested in CI: verify one plane matches bioio before
+    # trusting the S-index alignment; fall back to bioio on any mismatch.
+    if n_scenes > 1:
+        try:
+            probe = tuple(slice(None) if d in ("Y", "X") else 0 for d in order)
+            if not np.array_equal(
+                np.asarray(arr[probe].compute()),
+                np.asarray(image.dask_data[probe].compute()),
+            ):
+                return None
+        except Exception:
+            return None
+
+    return arr
+
+
 def bioio_reader(path: str | list[str]) -> List[Tuple[Any, dict, str]]:
     """
     Reader for bioio supported files
@@ -237,8 +340,11 @@ def bioio_reader(path: str | list[str]) -> List[Tuple[Any, dict, str]]:
         # optional kwargs for the corresponding viewer.add_* method
         add_kwargs = {}
 
-        # Get the dask data
-        data = image.dask_data
+        # Get the dask data. For CZIs, prefer a per-(T,C) bulk-read dask array
+        # (fast slicing); fall back to bioio's per-plane dask_data otherwise.
+        data = _czi_fast_dask_data(path, image)
+        if data is None:
+            data = image.dask_data
 
         # Get the dimensions
         dim_order = list(image.dims.order)

--- a/plugin/napari_lattice/utils.py
+++ b/plugin/napari_lattice/utils.py
@@ -26,6 +26,32 @@ def _transforms_equal(a: Any, b: Any) -> bool:
     return aa.shape == bb.shape and bool(np.allclose(aa, bb))
 
 
+def _embed_affine(matrix: Any, target_size: int):
+    """
+    Embed a ``(k+1)x(k+1)`` square homogeneous affine (k spatial dims) into a
+    ``target_size x target_size`` identity so it acts on the LAST k axes —
+    matching how napari coerces a smaller affine assigned to a higher-dimensional
+    layer (verified against napari for 4x4->5x5 and 4x4->6x6: linear block at
+    offset ``n-k``, translation in the last column).
+
+    Only a *square* matrix smaller than ``target_size`` is embedded; anything
+    else (non-square, non-2-D, or already ``>= target_size``) is returned
+    unchanged so the caller's equality check errs toward assigning rather than
+    silently mis-embedding a malformed input.
+    """
+    import numpy as np
+    m = np.asarray(matrix, dtype=float)
+    if m.ndim != 2 or m.shape[0] != m.shape[1] or m.shape[0] >= target_size:
+        return m
+    k = m.shape[0] - 1          # spatial dims of the given affine
+    n = target_size - 1         # spatial dims of the layer
+    offset = n - k
+    result = np.eye(target_size)
+    result[offset:offset + k, offset:offset + k] = m[:k, :k]     # linear part
+    result[offset:offset + k, n] = m[:k, k]                      # translation
+    return result
+
+
 def apply_layer_transform(image: Any, scale: Any = _UNSET, affine: Any = _UNSET) -> List[str]:
     """
     Assign ``scale``/``affine`` to a napari layer ONLY when the value actually
@@ -36,26 +62,49 @@ def apply_layer_transform(image: Any, scale: Any = _UNSET, affine: Any = _UNSET)
     tens of seconds, so skipping no-op assignments is the difference between an
     instant parameter tweak and a multi-second freeze.
 
+    The desired value is first normalized to the layer's dimensionality exactly
+    as napari would coerce it (a short scale is front-padded with 1.0; a small
+    affine is embedded into a layer-sized identity). Without this, a 3-tuple
+    scale / 4x4 affine assigned to a >3-D layer never shape-matches napari's
+    padded value, so the no-op skip is silently defeated for the very case it
+    exists to optimize.
+
     Pass ``_UNSET`` (the default) to leave a property alone. ``affine=None``
     means "reset to identity"; it is skipped only when the layer is already at
     identity. Returns the list of property names that were actually assigned,
     which callers use for logging and tests.
     """
+    import numpy as np
     changed: List[str] = []
 
     if scale is not _UNSET and scale is not None:
-        if not _transforms_equal(getattr(image, "scale", None), scale):
-            image.scale = scale
+        current_scale = getattr(image, "scale", None)
+        desired = tuple(scale)
+        if current_scale is not None and len(current_scale) > len(desired):
+            desired = (1.0,) * (len(current_scale) - len(desired)) + desired
+        if not _transforms_equal(current_scale, desired):
+            image.scale = desired
             changed.append("scale")
 
     if affine is not _UNSET:
         current = getattr(getattr(image, "affine", None), "affine_matrix", None)
-        desired = affine
-        if desired is None and current is not None:
-            import numpy as np
-            desired = np.eye(current.shape[0])
+        if affine is None:
+            # Reset to identity; compare against an identity of the layer's size.
+            desired = np.eye(current.shape[0]) if current is not None else None
+            assign_value = affine   # None -> napari coerces to identity
+        else:
+            assign_value = affine
+            try:
+                m = np.asarray(affine, dtype=float)
+                if current is not None and m.ndim == 2 and m.shape[0] < current.shape[0]:
+                    desired = _embed_affine(m, current.shape[0])
+                    assign_value = desired   # assign the embedded form napari would store
+                else:
+                    desired = m
+            except Exception:
+                desired = affine        # unusual input -> let _transforms_equal decide (assigns)
         if not _transforms_equal(current, desired):
-            image.affine = affine
+            image.affine = assign_value
             changed.append("affine")
 
     return changed

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "bioio>=3.0.0",
     "bioio-tifffile==1.3.0",
     "bioio-czi>=2.4.0",
+    # Imported directly in reader.py for fast CZI reads
+    # (also pulled in by bioio-czi).
+    "aicspylibczi",
     "dask[distributed]",
     # This isn't used directly, but we need to pin this version
     "fsspec>=2022.8.2",

--- a/plugin/tests/test_dock_widget.py
+++ b/plugin/tests/test_dock_widget.py
@@ -132,6 +132,42 @@ def test_get_kwargs_caches_reader(make_napari_viewer: Callable[[], Viewer], monk
         assert calls["n"] >= 1
 
 
+def test_quick_deskew_toggle_restores_raw_scale(make_napari_viewer: Callable[[], Viewer]):
+    """
+    Toggling Quick Deskew OFF must restore the raw-view scale. Regression for the
+    fix wiring `_rescale_image` to the `quick_deskew` signal — previously the
+    layer was left at the deskewed z-spacing after turning Quick Deskew off.
+    """
+    import numpy as np
+
+    viewer = make_napari_viewer()
+    with as_file(resources / "RBC_tiny.czi") as image_path:
+        image_data = BioImage(image_path)
+        viewer.add_image(image_data.xarray_dask_data)
+
+        ui = LLSZWidget()
+        set_debug(ui)
+        viewer.window.add_dock_widget(ui)
+
+        fields = ui.LlszMenu.WidgetContainer.deskew_fields
+        fields.img_layer.value = list(viewer.layers)
+        fields.dimension_order.value = image_data.dims.order
+        fields.pixel_sizes_source.value = PixelSizeSource.Manual
+        fields.pixel_sizes.value = (0.15, 0.15, 0.3)  # X, Y, Z
+
+        layer = list(viewer.layers)[0]
+        raw = tuple(np.asarray(layer.scale)[-3:])          # QD off after setup
+
+        fields.quick_deskew.value = True
+        deskewed = tuple(np.asarray(layer.scale)[-3:])     # deskewed z-spacing
+
+        fields.quick_deskew.value = False
+        restored = tuple(np.asarray(layer.scale)[-3:])     # must be raw again
+
+        assert deskewed != raw, "enabling Quick Deskew should change the scale"
+        assert np.allclose(restored, raw), "disabling Quick Deskew must restore raw scale"
+
+
 def test_check_buildable():
     ui = LLSZWidget()
     set_debug(ui)

--- a/plugin/tests/test_dock_widget.py
+++ b/plugin/tests/test_dock_widget.py
@@ -178,3 +178,55 @@ def test_check_buildable():
     set_debug(ui)
     check_function_gui_buildable(ui)
 
+
+def test_parallel_roi_save_off_main_thread():
+    """
+    Regression: calling LatticeData.save() from off the main thread (as the GUI
+    now does via thread_worker) must not break the parallel-ROI process/thread
+    pools. Engine correctness itself is covered in core/tests/test_parallel_processing.py.
+
+    Construction mirrors core/tests/test_parallel_processing.py::_make_lattice.
+    A 2-ROI crop with process_parallel=2 forces the parallel-ROI save path
+    (_use_parallel_roi_processing: >1 ROI and >1 worker).
+    """
+    import os
+    import numpy as np
+    from xarray import DataArray
+    from magicclass import magicclass
+    from magicclass.utils import thread_worker
+    from lls_core.models.lattice_data import LatticeData
+    from lls_core.models.crop import CropParams
+
+    def _roi(y0, x0, y1, x1):
+        return [[y0, x0], [y0, x1], [y1, x1], [y1, x0]]
+
+    raw = np.zeros((30, 90, 90), dtype=np.uint16)
+    rois = [_roi(0, 0, 30, 30), _roi(0, 30, 30, 60)]  # 2 ROIs
+
+    with TemporaryDirectory() as tmpdir:
+        lattice = LatticeData(
+            input_image=DataArray(raw, dims=["Z", "Y", "X"]),
+            physical_pixel_sizes=(1, 1, 1),
+            save_name="test",
+            save_dir=tmpdir,
+            save_type="tiff",
+            crop=CropParams(roi_list=rois, z_range=(0, 20)),
+            process_parallel=2,
+        )
+
+        # Sanity: this really is the parallel path, not the serial fallback.
+        assert lattice._use_parallel_roi_processing()
+
+        @magicclass
+        class _Runner:
+            @thread_worker
+            def run(self):
+                lattice.save()
+
+        runner = _Runner()
+        with thread_worker.blocking_mode():
+            runner.run()  # runs the worker body synchronously to completion
+
+        produced = list(os.scandir(tmpdir))
+        assert produced, "parallel ROI save produced no output files"
+

--- a/plugin/tests/test_dock_widget.py
+++ b/plugin/tests/test_dock_widget.py
@@ -6,6 +6,7 @@ from typing import Callable, TYPE_CHECKING
 from magicclass.testing import check_function_gui_buildable, FunctionGuiTester
 from magicclass import MagicTemplate
 from magicclass.widgets import Widget
+from magicclass.utils import thread_worker
 from magicclass._gui._gui_modes import ErrorMode
 import pytest
 from lls_core.sample import resources
@@ -69,16 +70,20 @@ def test_dock_widget(make_napari_viewer: Callable[[], Viewer], image_data: BioIm
         fields.dimension_order.value = image_data.dims.order
         fields.pixel_sizes_source.value = PixelSizeSource.Manual
 
-        # Test previewing
-        tester = FunctionGuiTester(ui.preview)
-        tester.call("", 0, 0)
+        # thread_worker methods run async on a QThread when called via the GUI;
+        # under test there is no spinning event loop, so force blocking mode so
+        # the worker bodies and their returned/yielded callbacks run synchronously.
+        with thread_worker.blocking_mode():
+            # Test previewing
+            tester = FunctionGuiTester(ui.preview)
+            tester.call("", 0, 0)
 
-        # Add the save path which shouldn't be needed for previewing
-        ui.LlszMenu.WidgetContainer.output_fields.save_path.value = tmpdir
-        
-        # Test saving
-        tester = FunctionGuiTester(ui.save)
-        tester.call()
+            # Add the save path which shouldn't be needed for previewing
+            ui.LlszMenu.WidgetContainer.output_fields.save_path.value = tmpdir
+
+            # Test saving
+            tester = FunctionGuiTester(ui.save)
+            tester.call()
 
 
 def test_get_kwargs_caches_reader(make_napari_viewer: Callable[[], Viewer], monkeypatch):

--- a/plugin/tests/test_layer_transform.py
+++ b/plugin/tests/test_layer_transform.py
@@ -90,9 +90,50 @@ def test_affine_none_clears_a_non_identity_affine():
 
 
 def test_new_affine_matrix_is_assigned():
+    # Pass a plain ndarray (as production does) so this exercises the numeric
+    # equality/embedding path, not the "unparseable input -> assign" fallback.
     layer = _FakeLayer(scale=(0.3, 0.15, 0.15), affine_matrix=np.eye(4))
     flip = np.eye(4)
     flip[0, 0] = -1
-    changed = apply_layer_transform(layer, affine=_FakeAffine(flip))
+    changed = apply_layer_transform(layer, affine=flip)
     assert changed == ["affine"]
     assert layer.affine_assignments == 1
+    assert layer.affine.affine_matrix[0, 0] == -1
+
+
+def test_equal_non_identity_affine_is_skipped():
+    # The affine analogue of the scale no-op test: re-applying an equal
+    # non-identity matrix must NOT re-assign (regression guard for the dedup).
+    flip = np.eye(4)
+    flip[0, 0] = -1
+    flip[0, 3] = 7
+    layer = _FakeLayer(scale=(0.3, 0.15, 0.15), affine_matrix=flip)
+    changed = apply_layer_transform(layer, affine=flip.copy())
+    assert changed == []
+    assert layer.affine_assignments == 0
+
+
+def test_short_scale_and_affine_skipped_on_higher_dim_layer():
+    # A >3D layer stores a length-4 scale and 5x5 affine. Re-applying the
+    # equivalent short (3-tuple scale / 4x4 affine) values must be recognized as
+    # a no-op. Regression for the dedup being defeated by the shape mismatch
+    # between napari's padded stored value and the short value passed in.
+    layer = _FakeLayer(scale=(1.0, 0.3, 0.15, 0.15), affine_matrix=np.eye(5))
+    changed = apply_layer_transform(layer, scale=(0.3, 0.15, 0.15), affine=np.eye(4))
+    assert changed == []
+    assert layer.scale_assignments == 0
+    assert layer.affine_assignments == 0
+
+
+def test_short_affine_change_on_higher_dim_layer_is_embedded_and_assigned():
+    # A genuine 4x4 change on a 4D layer must still assign, stored as the 5x5
+    # form napari would coerce it to (linear block at offset 1).
+    layer = _FakeLayer(scale=(1.0, 0.3, 0.15, 0.15), affine_matrix=np.eye(5))
+    flip = np.eye(4)
+    flip[0, 0] = -1
+    changed = apply_layer_transform(layer, affine=flip)
+    assert changed == ["affine"]
+    assert layer.affine_assignments == 1
+    stored = layer.affine.affine_matrix
+    assert stored.shape == (5, 5)
+    assert stored[1, 1] == -1  # flip's linear part embedded at offset 1


### PR DESCRIPTION
Pushed earlier fix to master by mistake..
Resuming fixes for slow GUI responses here:

- use aicspylibczi for direct czi read instead of bio-czi: Build a lazily-read dask array for a (non-mosaic) CZI, chunked per T,C via
    single bulk ``aicspylibczi`` reads. This is faster especially when slicing through single plane in napari due to the dask graph overhead.