### PR TITLE
Preserve dtype for deskewed data. Added tests. deconvolved stays floa…

### DIFF
--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -419,6 +419,24 @@ class LatticeData(OutputParams, DeskewParams):
         from dask.array import zeros
         return zeros(self.derived.deskew_vol_shape)
 
+    def _restore_input_dtype(self, data: ArrayLike) -> ArrayLike:
+        """
+        Return deskewed data to the dtype of the input image.
+
+        As Deskewing is on GPU, data is in float 32. 
+        Convert image back into input image type. 
+        Deconvolved data is kept as float 32. 
+        
+        Workflow outputs keep whatever dtype workflow produced.
+        """
+        import numpy as np
+        from lls_core.writers import resolve_output_dtype, to_output_dtype
+        if self.deconv_enabled:
+            return data
+        return to_output_dtype(
+            np.asarray(data), resolve_output_dtype(self.input_image.dtype)
+        )
+
     def _process_crop(self) -> Iterable[ImageSlice]:
         """
         Yields processed image slices with cropping enabled
@@ -438,7 +456,7 @@ class LatticeData(OutputParams, DeskewParams):
                 )
 
             yield slice.copy(update={
-                "data": crop_volume_deskew(
+                "data": self._restore_input_dtype(crop_volume_deskew(
                     original_volume=slice.data,
                     deconvolution=self.deconv_enabled,
                     get_deskew_and_decon=False,
@@ -455,7 +473,7 @@ class LatticeData(OutputParams, DeskewParams):
                     skew_dir=self.skew_dir,
                     coverslip_rotation=self.coverslip_rotation,
                     **deconv_args
-                ),
+                )),
                 "roi_index": roi_index
             })
             
@@ -492,14 +510,14 @@ class LatticeData(OutputParams, DeskewParams):
                     )
 
             yield slice.copy_with_data(
-                cle.pull_zyx(self.deskew_func(
+                self._restore_input_dtype(cle.pull_zyx(self.deskew_func(
                     input_image=data,
                     angle_in_degrees=self.angle,
                     linear_interpolation=True,
                     voxel_size_x=self.dx,
                     voxel_size_y=self.dy,
                     voxel_size_z=self.dz
-                ))
+                )))
             )
 
     def process_workflow(self) -> WorkflowSlices:

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterable, List, Optional
+import logging
 
 from lls_core.types import ArrayLike
 
@@ -16,23 +17,69 @@ import numpy as np
 import zarr
 
 from lls_core.utils import make_filename_suffix, get_zarr_compression, ZARR_MAJOR_VERSION
+
+logger = logging.getLogger(__name__)
+
 RoiIndex = Optional[NonNegativeInt]
 
+#: Dtypes OME-TIFF has no equivalent for (it supports (u)int8/16/32, float and
+#: double), mapped to the narrowest type that round-trips their values.
+_OME_DTYPE_FALLBACK = {
+    np.dtype(bool): np.dtype(np.uint8),
+    np.dtype(np.int64): np.dtype(np.int32),
+    np.dtype(np.uint64): np.dtype(np.uint32),
+    np.dtype(np.float16): np.dtype(np.float32),
+}
+
+
 def resolve_output_dtype(dtype: np.dtype) -> np.dtype:
-    """Pick the output dtype: keep float and small ints, cast larger ints (int32, int64) to uint16."""
+    """Preserve the input dtype wherever the format can represent it, so an
+    8-bit mask stays 8-bit and a 32-bit label image keeps IDs above 65535."""
     dtype = np.dtype(dtype)
-    if np.issubdtype(dtype, np.integer):
-        return dtype if np.iinfo(dtype).max < np.iinfo(np.uint16).max else np.dtype(np.uint16)
-    if np.issubdtype(dtype, np.floating):
+    if dtype in _OME_DTYPE_FALLBACK:
+        return _OME_DTYPE_FALLBACK[dtype]
+    if np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.floating):
         return dtype
     raise TypeError(f"Unsupported data dtype: {dtype}")
 
 
+def _representable_bounds(info: np.iinfo, float_dtype: np.dtype):
+    """The limits in ``info``, nudged inward until exactly representable in
+    ``float_dtype``. float32 rounds iinfo(int32).max *up*, so clipping to it
+    leaves values above the maximum and the cast then overflows."""
+    hi = np.array(info.max, dtype=float_dtype)
+    lo = np.array(info.min, dtype=float_dtype)
+    while float(hi) > info.max:
+        hi = np.nextafter(hi, np.array(0, dtype=float_dtype))
+    while float(lo) < info.min:
+        lo = np.nextafter(lo, np.array(0, dtype=float_dtype))
+    return lo, hi
+
+
 def to_output_dtype(array: np.ndarray, out_dtype: np.dtype) -> np.ndarray:
-    """Cast to ``out_dtype``, clipping to range only when casting to uint16."""
+    """Cast to ``out_dtype``, rounding and clipping for integer targets.
+    Deskew output is fractional: a plain ``.astype`` truncates toward zero,
+    pulling magnitudes down by about half a count, so round to nearest."""
     out_dtype = np.dtype(out_dtype)
-    if out_dtype == np.uint16 and array.dtype != np.uint16:
-        return np.clip(array, 0.0, 65535.0).astype(np.uint16)
+    array = np.asarray(array)
+    if array.dtype == out_dtype:
+        return array
+    if np.issubdtype(out_dtype, np.integer):
+        info = np.iinfo(out_dtype)
+        if np.issubdtype(array.dtype, np.floating):
+            # NaN casts to 0, indistinguishable from background, so say so.
+            nan_count = int(np.count_nonzero(np.isnan(array)))
+            if nan_count:
+                logger.warning(
+                    "%d voxel(s) were NaN and have been written as 0. This "
+                    "usually means deconvolution diverged.", nan_count
+                )
+                array = np.nan_to_num(array, nan=0.0, posinf=info.max, neginf=info.min)
+            array = np.rint(array)
+            lo, hi = _representable_bounds(info, array.dtype)
+        else:
+            lo, hi = info.min, info.max
+        return np.clip(array, lo, hi).astype(out_dtype, copy=False)
     return array.astype(out_dtype, copy=False)
 
 if TYPE_CHECKING:

--- a/core/tests/test_output_dtype.py
+++ b/core/tests/test_output_dtype.py
@@ -1,0 +1,72 @@
+"""
+Output dtype preservation: deskewing returns float32 from the GPU, so saving
+must restore the input dtype - 8-bit stays 8-bit, 32-bit labels stay 32-bit.
+"""
+import numpy as np
+import pytest
+import tifffile
+
+from lls_core.models.lattice_data import LatticeData
+from lls_core.writers import resolve_output_dtype, to_output_dtype
+
+
+@pytest.mark.parametrize("in_dtype,out_dtype", [
+    ("uint8", "uint8"),
+    ("uint16", "uint16"),
+    ("int32", "int32"),        # labels: was narrowed to uint16, clipping IDs
+    ("float32", "float32"),
+    ("bool", "uint8"),         # no 1-bit type in OME-TIFF; was a TypeError
+    ("int64", "int32"),        # no 64-bit int in OME-TIFF
+])
+def test_resolve_output_dtype(in_dtype, out_dtype):
+    assert resolve_output_dtype(np.dtype(in_dtype)) == np.dtype(out_dtype)
+
+
+def test_rounds_rather_than_truncates():
+    """A bare .astype() truncates, biasing every voxel down ~0.5 counts."""
+    arr = np.array([114.83, 82.099, 0.9, -2.7], dtype=np.float32)
+    np.testing.assert_array_equal(to_output_dtype(arr, np.dtype("int16")), [115, 82, 1, -3])
+
+
+@pytest.mark.parametrize("out_dtype", ["uint8", "uint16", "int32", "uint32"])
+def test_out_of_range_saturates_never_wraps(out_dtype, recwarn):
+    """iinfo(int32).max is not representable in float32, so the cast overflowed."""
+    info = np.iinfo(out_dtype)
+    out = to_output_dtype(np.array([1e30, -1e30], dtype=np.float32), np.dtype(out_dtype))
+    assert out[0] >= info.max * 0.99, f"positive overflow wrapped to {out[0]}"
+    assert out[1] <= 0, f"negative overflow wrapped to {out[1]}"
+    assert not [w for w in recwarn if "invalid value" in str(w.message)]
+
+
+def test_nan_is_zeroed_and_warned(caplog):
+    """NaN would silently become 0, indistinguishable from background."""
+    with caplog.at_level("WARNING"):
+        out = to_output_dtype(np.array([np.nan, 5.7], dtype=np.float32), np.dtype("uint16"))
+    assert out[0] == 0 and out[1] == 6
+    assert "NaN" in caplog.text
+
+
+def _lattice(tmp_path, raw):
+    return LatticeData(
+        input_image=raw, save_dir=str(tmp_path), save_name="t", save_type="tiff",
+        physical_pixel_sizes=(0.3, 0.1449, 0.1449),
+    )
+
+
+def test_deconvolution_output_stays_float32(tmp_path, monkeypatch):
+    """Deconvolved peaks legitimately exceed the input range, so are not cast."""
+    lattice = _lattice(tmp_path, np.zeros((5, 10, 10), dtype=np.uint16))
+    monkeypatch.setattr(type(lattice), "deconv_enabled", property(lambda _: True))
+    out = np.asarray(lattice._restore_input_dtype(np.array([[[70000.5]]], dtype=np.float32)))
+    assert out.dtype == np.float32 and out.max() > 65535
+
+
+def test_uint8_deskew_saves_as_uint8(tmp_path):
+    """The reported bug: 8-bit input came out wider after deskewing."""
+    raw = (np.random.default_rng(0).random((15, 40, 40)) * 200 + 50).astype(np.uint8)
+    _lattice(tmp_path, raw).save()
+    written = list(tmp_path.glob("*.tif*"))
+    assert len(written) == 1
+    data = tifffile.imread(str(written[0]))
+    assert data.dtype == np.uint8
+    assert data.max() > 100, f"output collapsed, max={data.max()}"


### PR DESCRIPTION
Improve how output data types are handled during deskewing and image processing, 

* new function `_restore_input_dtype` in `LatticeData` to convert deskewed data back to the input image's data type unless deconvolution is enabled, ensuring output matches the original dtype. 

* Updated `_process_crop` and `_process_non_crop` to use `_restore_input_dtype`, so that all workflow outputs maintain the correct data type.

**Testing and Validation:**

* Added a test module `test_output_dtype.py` with parameterized and functional tests to verify that output data types are preserved, rounding is correct, overflows saturate instead of wrapping, and NaN values are handled with warnings. Also tests that deconvolved data remains float32 and that 8-bit input saves as 8-bit output.
