### PR TITLE
imaris writer init

### DIFF
--- a/core/lls_core/imaris.py
+++ b/core/lls_core/imaris.py
@@ -1,0 +1,538 @@
+"""
+Imaris (v 5.5; ``.ims``) writing, implemented directly on top of ``h5py``.
+
+Why not PyImarisWriter
+----------------------
+Bitplane ship an official Python wrapper (``PyImarisWriter`` on PyPI), but 
+bundles only Windows libraries. In linux and macOS, you'll haev to build the 
+C++ project. Instead we create a custom imaris writer as 
+``.ims`` is plain HDF5 with a documented layout. This
+ensures no new dependency: ``h5py`` already is a part of ``npy2bdv``.
+
+Provenance
+----------
+Every convention below is taken from the reference implementation,
+``writer/bpWriterHDF5.cxx`` in https://github.com/imaris/ImarisWriter (Apache
+2.0), so that it can be re-checked. Line references are to that file at the
+time of writing. The layout is::
+
+    /                                   attrs: ImarisDataSet, ImarisVersion, ...
+    /DataSetInfo/Image                  attrs: X, Y, Z, ExtMin0..2, ExtMax0..2, Unit
+    /DataSetInfo/Channel {c}            attrs: Name, Color, ColorRange, ...
+    /DataSetInfo/TimeInfo               attrs: DatasetTimePoints, TimePoint1..N
+    /DataSet/ResolutionLevel {r}/TimePoint {t}/Channel {c}/Data       (Z, Y, X)
+                                        attrs: ImageSizeX/Y/Z, HistogramMin/Max
+                                                             .../Histogram   (256 x uint64)
+
+Two conventions that are easy to get wrong and explicitly mentioned here are:
+
+* **Strings are 1-D arrays of single characters**, not HDF5 strings.
+  ``bpWriterHDF5.cxx:670`` writes them as ``H5T_C_S1`` with the dataspace
+  length set to the string length, i.e. ``numpy`` dtype ``S1``.
+* **The ``Data`` dataspace is padded up to a whole number of chunks**
+  (``bpWriterHDF5.cxx:460-470``: ``fileSize = chunkSize * numChunks``). The true
+  size lives in the ``ImageSizeX/Y/Z`` attributes on the channel group, which is
+  what readers use.
+  
+  Claude Opus 4.8 used to convert the adapt PyImarisWriter to a pure Python implementation.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Imaris only understands these four sample types. Mirrors
+#: ``ConvertToHDF5DataType`` (``bpWriterHDF5.cxx:30-53``), which maps anything
+#: unrecognised to uint8; we would rather fail loudly, so unsupported dtypes are
+#: promoted by :func:`resolve_imaris_dtype` instead.
+IMARIS_DTYPES: Tuple[np.dtype, ...] = (
+    np.dtype(np.uint8),
+    np.dtype(np.uint16),
+    np.dtype(np.uint32),
+    np.dtype(np.float32),
+)
+
+#: ``bpMultiresolutionImsImage.cxx:708`` and ``:717`` both budget 1 MiB, then
+#: divide by the sample size to get a voxel count. Used for the pyramid cutoff
+#: and as the chunk budget.
+_ONE_MIB = 1024 * 1024
+
+#: Default per-channel display colours, matching the order Imaris itself uses
+#: for the first few channels of a multi-channel image.
+_DEFAULT_COLORS: Tuple[Tuple[float, float, float], ...] = (
+    (1.0, 0.0, 0.0),
+    (0.0, 1.0, 0.0),
+    (0.0, 0.0, 1.0),
+    (1.0, 1.0, 0.0),
+    (0.0, 1.0, 1.0),
+    (1.0, 0.0, 1.0),
+    (1.0, 1.0, 1.0),
+)
+
+
+def resolve_imaris_dtype(dtype: np.dtype) -> np.dtype:
+    """
+    Return the Imaris sample type to store ``dtype`` as.
+
+    Imaris supports only unsigned 8/16/32-bit integers and float32, so signed
+    integers, float64 and bool have to be promoted. Each is widened to the
+    narrowest supported type that cannot lose values, which keeps label images
+    (often int32) and masks (bool) intact.
+    """
+    dtype = np.dtype(dtype)
+    if dtype in IMARIS_DTYPES:
+        return dtype
+    if dtype == np.dtype(bool):
+        return np.dtype(np.uint8)
+    if dtype == np.dtype(np.float16):
+        return np.dtype(np.float32)
+    if np.issubdtype(dtype, np.floating):
+        # float64 -> float32 is the only float Imaris has; precision is lost but
+        # the alternative is not writing the image at all.
+        return np.dtype(np.float32)
+    if np.issubdtype(dtype, np.signedinteger):
+        # A signed type needs the *next* unsigned size up to hold its negative
+        # range once offset, but Imaris has no int types at all, so clipping at
+        # zero is unavoidable. Keep the same width so IDs above 65535 survive.
+        return np.dtype({1: np.uint8, 2: np.uint16, 4: np.uint32, 8: np.uint32}[dtype.itemsize])
+    if np.issubdtype(dtype, np.unsignedinteger):
+        # uint64 has no Imaris equivalent.
+        return np.dtype(np.uint32)
+    raise TypeError(f"Cannot store dtype {dtype} in an Imaris file")
+
+
+def optimal_image_pyramid(
+    shape_zyx: Tuple[int, int, int],
+    itemsize: int,
+    reduce_z: bool = True,
+    max_bytes: int = _ONE_MIB,
+) -> List[Tuple[int, int, int]]:
+    """
+    Resolution level sizes, as a faithful port of ``GetOptimalImagePyramid``
+    (``writer/bpOptimalBlockLayout.cxx``).
+
+    Levels are halved along whichever axes are still "long" relative to the
+    others, so an anisotropic deskewed volume is reduced towards isotropy rather
+    than blindly by 2 in every axis. Iteration stops once a level fits in
+    ``max_bytes``, or once no axis is eligible.
+
+    ``shape_zyx`` is in numpy order; the C++ works in (x, y, z), so the axes are
+    reversed on the way in and out.
+    """
+    max_voxels = max(int(max_bytes // itemsize), 1)
+    size = [int(shape_zyx[2]), int(shape_zyx[1]), int(shape_zyx[0])]  # x, y, z
+    result = [tuple(size)]
+
+    while size[0] * size[1] * size[2] > max_voxels:
+        large_x, large_y = size[0], size[1]
+        # When Z reduction is disabled the C++ substitutes 1 here, which also
+        # makes the reduce_z test below fail, so Z is left alone.
+        large_z = size[2] if reduce_z else 1
+
+        # The factor of 10 biases towards keeping an axis until it is roughly an
+        # order of magnitude smaller than the others.
+        do_x = large_x > 1 and (10 * large_x) * (10 * large_x) > large_y * large_z
+        do_y = large_y > 1 and (10 * large_y) * (10 * large_y) > large_x * large_z
+        do_z = large_z > 1 and (10 * large_z) * (10 * large_z) > large_x * large_y
+        if not (do_x or do_y or do_z):
+            break
+        if do_x:
+            size[0] //= 2
+        if do_y:
+            size[1] //= 2
+        if do_z:
+            size[2] //= 2
+        result.append(tuple(size))
+
+    # Back to (z, y, x).
+    return [(s[2], s[1], s[0]) for s in result]
+
+
+def chunk_shape(shape_zyx: Tuple[int, int, int], itemsize: int, max_bytes: int = _ONE_MIB) -> Tuple[int, int, int]:
+    """
+    Pick an HDF5 chunk shape of at most ``max_bytes``.
+
+    Deliberately *not* a port of ``GetOptimalBlockSize``, which searches
+    power-of-two layouts against a three-part rendering cost model. Chunk shape
+    only affects read performance, not whether Imaris can open the file, so the
+    ~80 lines of cost model are not worth carrying. Instead grow the smallest
+    axis repeatedly, which lands on the cube-ish, budget-filling shapes that
+    cost model prefers anyway.
+    """
+    limit = [max(int(s), 1) for s in shape_zyx]
+    budget = max(int(max_bytes // itemsize), 1)
+    chunk = [1, 1, 1]
+
+    while True:
+        # Prefer growing X, then Y, then Z, so a chunk stays contiguous on disk
+        # for the fastest-varying axis; among those, always grow the smallest.
+        candidates = [
+            axis for axis in (2, 1, 0)
+            if chunk[axis] < limit[axis] and np.prod(chunk) * 2 <= budget
+        ]
+        if not candidates:
+            break
+        axis = min(candidates, key=lambda a: (chunk[a], -a))
+        chunk[axis] *= 2
+
+    return (min(chunk[0], limit[0]), min(chunk[1], limit[1]), min(chunk[2], limit[2]))
+
+
+def _ims_string(value: str) -> np.ndarray:
+    """
+    Encode ``value`` the way Imaris stores string attributes: a 1-D array of
+    single characters (``bpWriterHDF5.cxx:670``), not an HDF5 string.
+
+    Empty strings become a single NUL, matching the zero-length special case at
+    ``bpWriterHDF5.cxx:757``, because HDF5 rejects a zero-length dataspace.
+    """
+    encoded = value.encode("ascii", errors="replace")
+    if not encoded:
+        encoded = b"\0"
+    return np.frombuffer(encoded, dtype="S1")
+
+
+def _fmt_float(value: float, precision: int = 3) -> str:
+    """``bpFloatToString`` (``bpWriterHDF5.cxx:82``): fixed-point, 3 dp default."""
+    return f"{float(value):.{precision}f}"
+
+
+def _fmt_time(when: datetime) -> str:
+    """
+    ``bpImsUtils::TimeInfoToString``. ``ToString`` defaults to
+    ``decimals=2, leadingZeros=true`` (``bpImsUtils.h:36``) so the date and time
+    parts are zero-padded, and milliseconds are appended only when non-zero
+    (``bpImsUtils.cxx:117``).
+    """
+    stamp = f"{when.year:04d}-{when.month:02d}-{when.day:02d} {when.hour:02d}:{when.minute:02d}:{when.second:02d}"
+    millisecond = when.microsecond // 1000
+    if millisecond > 0:
+        stamp += f".{millisecond:03d}"
+    return stamp
+
+
+def _downsample(volume: np.ndarray, factors: Tuple[int, int, int]) -> np.ndarray:
+    """
+    Reduce ``volume`` by integer ``factors`` using a block mean.
+
+    Averaging (rather than striding) is what keeps a downsampled level a fair
+    preview of the level above: subsampling a deskewed volume, which is mostly
+    interpolated black space, aliases badly. Trailing voxels that do not fill a
+    whole block are dropped, which matches the ``size // 2`` level sizes that
+    :func:`optimal_image_pyramid` produces for odd inputs.
+    """
+    if factors == (1, 1, 1):
+        return volume
+    fz, fy, fx = factors
+    trimmed = volume[
+        : (volume.shape[0] // fz) * fz,
+        : (volume.shape[1] // fy) * fy,
+        : (volume.shape[2] // fx) * fx,
+    ]
+    # Accumulate in a wider type so summing blocks of uint8/uint16 cannot wrap.
+    accum = np.float32 if trimmed.dtype == np.float32 else np.float64
+    reshaped = trimmed.reshape(
+        trimmed.shape[0] // fz, fz,
+        trimmed.shape[1] // fy, fy,
+        trimmed.shape[2] // fx, fx,
+    )
+    reduced = reshaped.mean(axis=(1, 3, 5), dtype=accum)
+    if np.issubdtype(volume.dtype, np.integer):
+        reduced = np.rint(reduced)
+    return reduced.astype(volume.dtype, copy=False)
+
+
+class ImsWriter:
+    """
+    Incremental Imaris 5.5 writer.
+
+    Volumes are handed over one ``(t, c)`` at a time via :meth:`write_volume`,
+    in any order, and each is immediately expanded into every resolution level.
+    Nothing is buffered between calls, so peak memory is one input volume plus
+    its first reduction (an eighth of the size).
+
+    Metadata that depends on the data as a whole -- the display range taken from
+    the accumulated histograms -- is written by :meth:`close`.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        shape_tczyx: Tuple[int, int, int, int, int],
+        dtype: np.dtype,
+        voxel_size_zyx: Tuple[float, float, float],
+        channel_names: Optional[Sequence[str]] = None,
+        channel_colors: Optional[Sequence[Tuple[float, float, float]]] = None,
+        unit: str = "um",
+        compression: Optional[str] = "gzip",
+        compression_opts: Optional[int] = 2,
+        image_name: Optional[str] = None,
+        recording_date: Optional[datetime] = None,
+        application_name: str = "napari-lattice",
+        application_version: str = "",
+        reduce_z: bool = True,
+    ) -> None:
+        import h5py
+
+        self.path = Path(path)
+        self.n_t, self.n_c, n_z, n_y, n_x = (int(v) for v in shape_tczyx)
+        self.shape_zyx = (n_z, n_y, n_x)
+        self.dtype = resolve_imaris_dtype(dtype)
+        self.voxel_size_zyx = tuple(float(v) for v in voxel_size_zyx)
+        self.unit = unit
+        self.compression = compression
+        self.compression_opts = compression_opts
+        self.image_name = image_name or self.path.stem
+        self.recording_date = recording_date or datetime.now()
+        self.application_name = application_name
+        self.application_version = application_version
+
+        self.channel_names = list(channel_names) if channel_names is not None else [f"Channel {c}" for c in range(self.n_c)]
+        if len(self.channel_names) != self.n_c:
+            raise ValueError(f"Expected {self.n_c} channel names, got {len(self.channel_names)}")
+        if channel_colors is not None:
+            self.channel_colors = [tuple(c) for c in channel_colors]
+        else:
+            self.channel_colors = [_DEFAULT_COLORS[c % len(_DEFAULT_COLORS)] for c in range(self.n_c)]
+
+        self.levels = optimal_image_pyramid(self.shape_zyx, self.dtype.itemsize, reduce_z=reduce_z)
+        self.chunks = [chunk_shape(level, self.dtype.itemsize) for level in self.levels]
+
+        #: (channel, level) -> running (min, max) across timepoints, used for the
+        #: display range that Imaris opens the image with.
+        self._ranges: Dict[Tuple[int, int], Tuple[float, float]] = {}
+
+        self.file = h5py.File(str(self.path), "w")
+        self._write_root_attrs()
+
+    # -- writing ---------------------------------------------------------
+
+    def write_volume(self, time_index: int, channel_index: int, volume: np.ndarray) -> None:
+        """Write one ``(Z, Y, X)`` volume and all of its reduced levels."""
+        if not 0 <= time_index < self.n_t:
+            raise IndexError(f"time_index {time_index} out of range for T={self.n_t}")
+        if not 0 <= channel_index < self.n_c:
+            raise IndexError(f"channel_index {channel_index} out of range for C={self.n_c}")
+
+        volume = np.asanyarray(volume)
+        if volume.ndim != 3:
+            raise ValueError(f"Expected a (Z, Y, X) volume, got shape {volume.shape}")
+        if volume.shape != self.shape_zyx:
+            raise ValueError(f"Volume shape {volume.shape} does not match {self.shape_zyx}")
+
+        current = self._as_imaris_dtype(volume)
+        for level, level_shape in enumerate(self.levels):
+            if level > 0:
+                previous = self.levels[level - 1]
+                # Levels only ever shrink by 1x or 2x per axis, so the ratio is
+                # the reduction factor.
+                factors = tuple(
+                    2 if level_shape[axis] * 2 <= previous[axis] else 1
+                    for axis in range(3)
+                )
+                current = _downsample(current, factors)
+                # optimal_image_pyramid floor-divides, so an odd axis leaves one
+                # extra plane/row that _downsample already dropped; trim any
+                # residual so the stored array matches the declared level size.
+                current = current[: level_shape[0], : level_shape[1], : level_shape[2]]
+            self._write_level(level, time_index, channel_index, current)
+
+    def _as_imaris_dtype(self, volume: np.ndarray) -> np.ndarray:
+        """
+        Cast to the file's sample type.
+
+        Delegates to the shared :func:`lls_core.writers.to_output_dtype` so the
+        Imaris path rounds, clips and reports NaNs exactly like the TIFF and Zarr
+        writers do -- in particular it clips to bounds that are *exactly
+        representable* in the source float type, which a plain
+        ``clip(iinfo.min, iinfo.max)`` gets wrong for uint32 targets. Imported
+        here rather than at module scope to keep this module importable without
+        the rest of ``lls_core``.
+        """
+        if volume.dtype == self.dtype:
+            return np.ascontiguousarray(volume)
+        from lls_core.writers import to_output_dtype
+
+        return np.ascontiguousarray(to_output_dtype(np.asarray(volume), self.dtype))
+
+    def _write_level(self, level: int, time_index: int, channel_index: int, volume: np.ndarray) -> None:
+        group_path = f"DataSet/ResolutionLevel {level}/TimePoint {time_index}/Channel {channel_index}"
+        group = self.file.require_group(group_path)
+        level_shape = self.levels[level]
+        chunks = self.chunks[level]
+
+        if "Data" in group:
+            dataset = group["Data"]
+        else:
+            # Pad the dataspace up to whole chunks, as the reference writer does
+            # (bpWriterHDF5.cxx:460-470). The real extent is recorded in the
+            # ImageSize* attributes below.
+            padded = tuple(
+                -(-level_shape[axis] // chunks[axis]) * chunks[axis]
+                for axis in range(3)
+            )
+            dataset = group.create_dataset(
+                "Data",
+                shape=padded,
+                dtype=self.dtype,
+                chunks=chunks,
+                compression=self.compression,
+                compression_opts=self.compression_opts if self.compression == "gzip" else None,
+            )
+            group.attrs["ImageSizeX"] = _ims_string(str(level_shape[2]))
+            group.attrs["ImageSizeY"] = _ims_string(str(level_shape[1]))
+            group.attrs["ImageSizeZ"] = _ims_string(str(level_shape[0]))
+
+        dataset[: volume.shape[0], : volume.shape[1], : volume.shape[2]] = volume
+        self._write_histogram(group, channel_index, level, volume)
+
+    def _write_histogram(self, group, channel_index: int, level: int, volume: np.ndarray) -> None:
+        """
+        Write the 256-bin histogram Imaris uses to seed contrast settings
+        (``bpWriterHDF5.cxx:216-278``).
+
+        The reference writer also emits a 1024-bin ``Histogram1024`` when the
+        source histogram has a different bin count; 256 bins is what every
+        reader looks for, so only that is written here.
+        """
+        # Masking copies the whole volume, which for a multi-GB float deskew is
+        # the difference between fitting in memory and not, so only pay for it
+        # when there is actually something non-finite to exclude.
+        finite = volume
+        if np.issubdtype(volume.dtype, np.floating):
+            mask = np.isfinite(volume)
+            if not mask.all():
+                finite = volume[mask]
+            del mask
+        if finite.size == 0:
+            low, high = 0.0, 1.0
+        else:
+            low, high = float(finite.min()), float(finite.max())
+        if high <= low:
+            # A constant image would give a zero-width range, which Imaris shows
+            # as fully saturated.
+            high = low + 1.0
+
+        counts, _ = np.histogram(finite, bins=256, range=(low, high))
+
+        group.attrs["HistogramMin"] = _ims_string(_fmt_float(low))
+        group.attrs["HistogramMax"] = _ims_string(_fmt_float(high))
+        if "Histogram" in group:
+            del group["Histogram"]
+        group.create_dataset("Histogram", data=counts.astype(np.uint64))
+
+        key = (channel_index, level)
+        seen = self._ranges.get(key)
+        self._ranges[key] = (low, high) if seen is None else (min(seen[0], low), max(seen[1], high))
+
+    # -- metadata --------------------------------------------------------
+
+    def _write_root_attrs(self) -> None:
+        """``bpWriterHDF5.cxx:155-163``."""
+        attrs = self.file.attrs
+        attrs["ImarisDataSet"] = _ims_string("ImarisDataSet")
+        attrs["ImarisVersion"] = _ims_string("5.5.0")
+        attrs["DataSetInfoDirectoryName"] = _ims_string("DataSetInfo")
+        attrs["ThumbnailDirectoryName"] = _ims_string("Thumbnail")
+        attrs["DataSetDirectoryName"] = _ims_string("DataSet")
+        attrs["NumberOfDataSets"] = np.array([1], dtype=np.uint32)
+
+    def _write_metadata(self) -> None:
+        """Populate ``/DataSetInfo`` (``bpWriterHDF5.cxx:566-660``)."""
+        n_z, n_y, n_x = self.shape_zyx
+        dz, dy, dx = self.voxel_size_zyx
+        stamp = _fmt_time(self.recording_date)
+
+        sections: Dict[str, Dict[str, str]] = {}
+
+        sections["ImarisDataSet"] = {
+            "NumberOfImages": "1",
+            "Creator": self.application_name,
+            "Version": self.application_version,
+        }
+        # An empty Log section still gets an Entries count.
+        sections["Log"] = {"Entries": "0"}
+
+        # Extents are the outer bounds of the voxel grid in physical units, so a
+        # size-N axis spans N * pixel_size. AdaptExtents
+        # (bpWriterHDF5.cxx:98-107) substitutes the voxel count when min == max,
+        # which would silently give a 1 unit/voxel image, so never emit a
+        # degenerate extent: fall back to a unit spacing instead.
+        extents = []
+        for size, spacing in ((n_x, dx), (n_y, dy), (n_z, dz)):
+            span = float(size) * float(spacing)
+            extents.append(span if span > 0 else float(size))
+
+        sections["Image"] = {
+            "Name": self.image_name,
+            "Description": "(description not specified)",
+            "X": str(n_x),
+            "Y": str(n_y),
+            "Z": str(n_z),
+            "Unit": self.unit,
+            "ExtMin0": _fmt_float(0.0, 9),
+            "ExtMin1": _fmt_float(0.0, 9),
+            "ExtMin2": _fmt_float(0.0, 9),
+            "ExtMax0": _fmt_float(extents[0], 9),
+            "ExtMax1": _fmt_float(extents[1], 9),
+            "ExtMax2": _fmt_float(extents[2], 9),
+            "ResampleDimensionX": "true",
+            "ResampleDimensionY": "true",
+            "ResampleDimensionZ": "true",
+            "RecordingDate": stamp,
+        }
+
+        time_info = {
+            "DatasetTimePoints": str(self.n_t),
+            "FileTimePoints": str(self.n_t),
+        }
+        # TimePoint numbering in DataSetInfo is 1-based, unlike the group names
+        # under /DataSet (bpWriterHDF5.cxx:638).
+        for t in range(self.n_t):
+            time_info[f"TimePoint{t + 1}"] = stamp
+        sections["TimeInfo"] = time_info
+
+        for c in range(self.n_c):
+            red, green, blue = self.channel_colors[c]
+            # Seed the display range from level 0 so the image opens with usable
+            # contrast; this is what ImarisWriter's adjust_color_range does.
+            low, high = self._ranges.get((c, 0), (0.0, 255.0))
+            sections[f"Channel {c}"] = {
+                "Name": self.channel_names[c],
+                "Description": "(description not specified)",
+                "ColorMode": "BaseColor",
+                "Color": " ".join(_fmt_float(v) for v in (red, green, blue)),
+                "ColorRange": f"{_fmt_float(low)} {_fmt_float(high)}",
+                "ColorOpacity": _fmt_float(1.0),
+                "GammaCorrection": _fmt_float(1.0),
+            }
+
+        info = self.file.require_group("DataSetInfo")
+        for section_name, values in sections.items():
+            # EncodeName (bpWriterHDF5.cxx:169-174): '%' then '/' are escaped so
+            # a parameter name cannot create a nested group.
+            group = info.require_group(section_name.replace("%", "%p").replace("/", "%s"))
+            for key, value in values.items():
+                group.attrs[key] = _ims_string(value)
+
+    def close(self) -> None:
+        if self.file is None:
+            return
+        try:
+            self._write_metadata()
+        finally:
+            self.file.close()
+            self.file = None
+
+    def __enter__(self) -> "ImsWriter":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -793,11 +793,13 @@ class LatticeData(OutputParams, DeskewParams):
         raise Exception("No slices produced!")
 
     def get_writer(self) -> Type[Writer]:
-        from lls_core.writers import BdvWriter, TiffWriter, OMEZarrWriter
+        from lls_core.writers import BdvWriter, ImarisWriter, TiffWriter, OMEZarrWriter
         if self.save_type == SaveFileType.h5:
             return BdvWriter
         elif self.save_type == SaveFileType.tiff:
             return TiffWriter
         elif self.save_type == SaveFileType.omezarr:
             return OMEZarrWriter
+        elif self.save_type == SaveFileType.imaris:
+            return ImarisWriter
         raise Exception("Unknown output type")

--- a/core/lls_core/models/output.py
+++ b/core/lls_core/models/output.py
@@ -15,6 +15,7 @@ class SaveFileType(StrEnum):
     h5 = "h5"
     tiff = "tiff"
     omezarr = "omezarr"
+    imaris = "imaris"
 
 class MipInterpolation(StrEnum):
     """
@@ -38,7 +39,7 @@ class OutputParams(FieldAccessModel):
     )
     save_type: SaveFileType = Field(
         default=SaveFileType.h5,
-        description=f"The data type to save the result as. This will also be used to determine the file extension of the output files. Choices: `{enum_choices(SaveFileType)}`. Choices can alternatively be specifed as `str`, for example `'tiff'`. Note: `tiff` is saved as a compressed OME-TIFF (`.ome.tif`)."
+        description=f"The data type to save the result as. This will also be used to determine the file extension of the output files. Choices: `{enum_choices(SaveFileType)}`. Choices can alternatively be specifed as `str`, for example `'tiff'`. Note: `tiff` is saved as a compressed OME-TIFF (`.ome.tif`), and `imaris` as a multi-resolution Imaris 5.5 file (`.ims`)."
     )
     time_range: range = Field(
         default=None,
@@ -101,6 +102,8 @@ class OutputParams(FieldAccessModel):
             return "h5"
         elif self.save_type == SaveFileType.omezarr:
             return "ome.zarr"
+        elif self.save_type == SaveFileType.imaris:
+            return "ims"
         else:
             # TIFF is written as a compressed OME-TIFF by default. The legacy
             # uncompressed path renames itself back to plain ".tif".

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -85,6 +85,7 @@ def to_output_dtype(array: np.ndarray, out_dtype: np.dtype) -> np.ndarray:
 if TYPE_CHECKING:
     from lls_core.models.lattice_data import LatticeData
     import npy2bdv
+    from lls_core.imaris import ImsWriter
     from lls_core.models.results import ProcessedSlice, ImageSlice
     from pathlib import Path
 
@@ -340,6 +341,71 @@ class TiffWriter(Writer):
                 metadata=ome_metadata,
             )
         self.written_files.append(path)
+
+def _lls_core_version() -> str:
+    """Installed ``lls_core`` version, or an empty string if it cannot be found
+    (e.g. running from a source tree that was never installed)."""
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        return version("lls_core")
+    except PackageNotFoundError:
+        return ""
+
+@dataclass
+class ImarisWriter(Writer):
+    """
+    A writer for the Imaris 5.5 (``.ims``) format.
+
+    One file per ROI holding every timepoint and channel, with a
+    multi-resolution pyramid so that Imaris can navigate large deskewed volumes
+    without loading them whole. Written directly through ``h5py`` rather than
+    Bitplane's ``PyImarisWriter``, whose PyPI wheel only ships Windows binaries;
+    see :mod:`lls_core.imaris` for the format details.
+    """
+    #: HDF5 compression filter for the voxel data. ``'gzip'`` matches the
+    #: reference writer's default (Gzip level 2); ``None`` disables compression.
+    compression: Optional[str] = "gzip"
+    compression_level: int = 2
+    ims_writer: Optional["ImsWriter"] = field(default=None, init=False)
+
+    def write_slice(self, slice: ProcessedSlice[ArrayLike]):
+        import numpy as np
+
+        data = np.asarray(slice.data)
+        if data.ndim != 3:
+            raise ValueError(f"Expected a (Z, Y, X) slice, got shape {data.shape}")
+
+        if self.ims_writer is None:
+            from lls_core.imaris import ImsWriter
+
+            suffix = f"_{make_filename_suffix(roi_index=str(self.roi_index))}" if self.roi_index is not None else ""
+            path = self.lattice.make_filepath(suffix)
+            channel_range = list(self.lattice.channel_range)
+            self.ims_writer = ImsWriter(
+                path,
+                shape_tczyx=(len(self.lattice.time_range), len(channel_range), *data.shape),
+                dtype=data.dtype,
+                # Deskewing changes the Z step, so the output spacing is new_dz.
+                voxel_size_zyx=(self.lattice.new_dz, self.lattice.dy, self.lattice.dx),
+                channel_names=[f"Channel {channel}" for channel in channel_range],
+                compression=self.compression,
+                compression_opts=self.compression_level,
+                image_name=self.lattice.save_name,
+                # Recorded as Creator/Version under /DataSetInfo/ImarisDataSet,
+                # so a file carries the version that produced it.
+                application_name="napari-lattice",
+                application_version=_lls_core_version(),
+            )
+            self.written_files.append(path)
+
+        # Indices (rather than the labels in slice.time/slice.channel) so that a
+        # subset like --channel-range 2 4 still starts from 0 and is contiguous.
+        self.ims_writer.write_volume(slice.time_index, slice.channel_index, data)
+
+    def close(self):
+        if self.ims_writer is not None:
+            self.ims_writer.close()
+            self.ims_writer = None
 
 @dataclass
 class OMEZarrWriter(Writer):

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -44,6 +44,9 @@ dependencies = [
     "dask",
     "dask[distributed]",
     "fsspec>=2022.8.2",
+    # Already pulled in by npy2bdv, but named explicitly because the Imaris
+    # (.ims) writer depends on it directly.
+    "h5py",
     "importlib_resources",
     "napari-workflows>=0.2.8",
     "npy2bdv",

--- a/core/tests/params.py
+++ b/core/tests/params.py
@@ -12,6 +12,7 @@ parameterized = pytest.mark.parametrize("args", [
     {"save_type": SaveFileType.h5},
     {"save_type": SaveFileType.tiff},
     {"save_type": SaveFileType.omezarr},
+    {"save_type": SaveFileType.imaris},
 ])
 
 # Allows parameterisation over two serialization formats

--- a/core/tests/test_imaris.py
+++ b/core/tests/test_imaris.py
@@ -1,0 +1,367 @@
+"""
+Tests for the Imaris (.ims) writer.
+
+The layout assertions here are transcribed from the reference implementation,
+``writer/bpWriterHDF5.cxx`` in https://github.com/imaris/ImarisWriter, so that a
+future change to :mod:`lls_core.imaris` that drifts from the Imaris conventions
+fails here rather than in Imaris.
+"""
+import numpy as np
+import pytest
+
+h5py = pytest.importorskip("h5py")
+
+from lls_core.imaris import (
+    ImsWriter,
+    chunk_shape,
+    optimal_image_pyramid,
+    resolve_imaris_dtype,
+)
+
+
+def read_attr(obj, name: str) -> str:
+    """
+    Decode an Imaris string attribute.
+
+    Deliberately the same expression the third-party reader uses
+    (``imaris_ims_file_reader``: ``str(hf[loc].attrs[attrib], encoding='ascii')``),
+    so that these tests fail if we ever write real HDF5 strings instead of the
+    array-of-single-characters that Imaris expects.
+    """
+    return str(obj.attrs[name], encoding="ascii")
+
+
+class TestDtypeMapping:
+    @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.float32])
+    def test_supported_dtypes_are_preserved(self, dtype):
+        assert resolve_imaris_dtype(np.dtype(dtype)) == np.dtype(dtype)
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (bool, np.uint8),
+            (np.int8, np.uint8),
+            (np.int16, np.uint16),
+            # Label images are commonly int32; the width must survive so IDs
+            # above 65535 are not collapsed.
+            (np.int32, np.uint32),
+            (np.float64, np.float32),
+            (np.float16, np.float32),
+            (np.uint64, np.uint32),
+        ],
+    )
+    def test_unsupported_dtypes_are_promoted(self, source, expected):
+        assert resolve_imaris_dtype(np.dtype(source)) == np.dtype(expected)
+
+
+class TestPyramid:
+    def test_small_image_is_single_level(self):
+        # 32*32*8 = 8192 voxels, far under the 1 MiB / 2 byte budget.
+        assert optimal_image_pyramid((8, 32, 32), 2) == [(8, 32, 32)]
+
+    def test_levels_shrink_monotonically_and_terminate(self):
+        levels = optimal_image_pyramid((109, 3840, 5112), 2)
+        assert levels[0] == (109, 3840, 5112)
+        assert len(levels) > 1
+        for finer, coarser in zip(levels, levels[1:]):
+            assert all(c <= f for c, f in zip(coarser, finer))
+            assert coarser != finer
+        # The last level must fit the budget, which is what makes Imaris
+        # responsive when it first opens the image.
+        assert np.prod(levels[-1]) <= (1024 * 1024) // 2
+
+    def test_thin_z_is_not_reduced_below_one(self):
+        # A MIP-like singleton Z must never be halved to zero.
+        levels = optimal_image_pyramid((1, 2048, 2048), 2)
+        assert all(level[0] == 1 for level in levels)
+
+    def test_reduce_z_disabled_keeps_z(self):
+        levels = optimal_image_pyramid((64, 1024, 1024), 2, reduce_z=False)
+        assert all(level[0] == 64 for level in levels)
+
+    def test_anisotropy_is_reduced_towards_isotropy(self):
+        """
+        The reference algorithm halves only axes that are still long relative to
+        the others, so a very wide, thin volume loses X and Y before Z.
+        """
+        levels = optimal_image_pyramid((16, 2048, 2048), 2)
+        # Z (16) is much shorter than X/Y (2048), so the first step must leave it
+        # alone and reduce the long axes.
+        assert levels[1] == (16, 1024, 1024)
+
+
+class TestChunks:
+    def test_chunk_never_exceeds_image(self):
+        shape = (3, 7, 11)
+        assert chunk_shape(shape, 2) == shape
+
+    def test_chunk_fits_budget(self):
+        chunk = chunk_shape((109, 3840, 5112), 2)
+        assert np.prod(chunk) * 2 <= 1024 * 1024
+        # Cube-ish, not a single degenerate plane.
+        assert all(c > 1 for c in chunk)
+
+
+@pytest.fixture
+def volume():
+    rng = np.random.default_rng(0)
+    return rng.integers(0, 4096, size=(16, 64, 48), dtype=np.uint16)
+
+
+@pytest.fixture
+def written(tmp_path, volume):
+    """A 2 timepoint, 2 channel file with distinguishable content per (t, c)."""
+    path = tmp_path / "test.ims"
+    with ImsWriter(
+        path,
+        shape_tczyx=(2, 2, *volume.shape),
+        dtype=volume.dtype,
+        voxel_size_zyx=(2.0, 0.145, 0.145),
+        channel_names=["green", "red"],
+    ) as writer:
+        for t in range(2):
+            for c in range(2):
+                writer.write_volume(t, c, (volume + (10 * t + c)).astype(np.uint16))
+    return path, volume
+
+
+class TestLayout:
+    def test_root_attributes(self, written):
+        path, _ = written
+        with h5py.File(path, "r") as f:
+            assert read_attr(f, "ImarisDataSet") == "ImarisDataSet"
+            assert read_attr(f, "ImarisVersion") == "5.5.0"
+            assert read_attr(f, "DataSetDirectoryName") == "DataSet"
+            assert read_attr(f, "DataSetInfoDirectoryName") == "DataSetInfo"
+            assert f.attrs["NumberOfDataSets"][0] == 1
+
+    def test_strings_are_character_arrays(self, written):
+        """
+        The single most likely way to produce a file Imaris cannot read: writing
+        HDF5 strings instead of ``S1`` arrays (bpWriterHDF5.cxx:670).
+        """
+        path, _ = written
+        with h5py.File(path, "r") as f:
+            raw = f["DataSetInfo/Image"].attrs["X"]
+            assert raw.dtype == np.dtype("S1")
+            assert raw.shape == (2,)  # "48"
+
+    def test_group_hierarchy(self, written):
+        path, _ = written
+        with h5py.File(path, "r") as f:
+            for t in range(2):
+                for c in range(2):
+                    group = f[f"DataSet/ResolutionLevel 0/TimePoint {t}/Channel {c}"]
+                    assert "Data" in group
+                    assert "Histogram" in group
+
+    def test_image_section_records_level_zero_size(self, written):
+        path, volume = written
+        n_z, n_y, n_x = volume.shape
+        with h5py.File(path, "r") as f:
+            image = f["DataSetInfo/Image"]
+            assert int(read_attr(image, "X")) == n_x
+            assert int(read_attr(image, "Y")) == n_y
+            assert int(read_attr(image, "Z")) == n_z
+            assert read_attr(image, "Unit") == "um"
+
+    def test_extents_encode_voxel_size(self, written):
+        """Imaris derives voxel size from extent / image size, so this is how
+        the 0.145 x 0.145 x 2.0 um spacing reaches the viewer."""
+        path, volume = written
+        n_z, n_y, n_x = volume.shape
+        with h5py.File(path, "r") as f:
+            image = f["DataSetInfo/Image"]
+            ext = [float(read_attr(image, f"ExtMax{i}")) for i in range(3)]
+            assert [float(read_attr(image, f"ExtMin{i}")) for i in range(3)] == [0.0, 0.0, 0.0]
+            assert ext[0] / n_x == pytest.approx(0.145)
+            assert ext[1] / n_y == pytest.approx(0.145)
+            assert ext[2] / n_z == pytest.approx(2.0)
+
+    def test_time_info_is_one_based(self, written):
+        """
+        Group names under /DataSet are 0-based but DataSetInfo/TimeInfo counts
+        from 1 (bpWriterHDF5.cxx:638).
+        """
+        path, _ = written
+        with h5py.File(path, "r") as f:
+            info = f["DataSetInfo/TimeInfo"]
+            assert read_attr(info, "DatasetTimePoints") == "2"
+            assert read_attr(info, "FileTimePoints") == "2"
+            assert "TimePoint1" in info.attrs
+            assert "TimePoint2" in info.attrs
+            assert "TimePoint0" not in info.attrs
+
+    def test_channel_metadata(self, written):
+        path, _ = written
+        with h5py.File(path, "r") as f:
+            assert read_attr(f["DataSetInfo/Channel 0"], "Name") == "green"
+            assert read_attr(f["DataSetInfo/Channel 1"], "Name") == "red"
+            assert read_attr(f["DataSetInfo/Channel 0"], "ColorMode") == "BaseColor"
+            # Three space separated floats.
+            assert len(read_attr(f["DataSetInfo/Channel 0"], "Color").split()) == 3
+            low, high = read_attr(f["DataSetInfo/Channel 0"], "ColorRange").split()
+            assert float(high) > float(low)
+
+
+class TestData:
+    def test_roundtrip_is_lossless(self, written):
+        """
+        Level 0 must be bit-exact: the pyramid is a preview, the base level is
+        the data.
+        """
+        path, volume = written
+        n_z, n_y, n_x = volume.shape
+        with h5py.File(path, "r") as f:
+            for t in range(2):
+                for c in range(2):
+                    data = f[f"DataSet/ResolutionLevel 0/TimePoint {t}/Channel {c}/Data"]
+                    stored = data[:n_z, :n_y, :n_x]
+                    np.testing.assert_array_equal(stored, volume + (10 * t + c))
+
+    def test_dataspace_is_chunk_padded(self, written):
+        """
+        Imaris pads the dataspace to whole chunks and records the true size in
+        ImageSize* (bpWriterHDF5.cxx:460-470). Readers rely on that, so verify
+        both halves of the contract.
+        """
+        path, volume = written
+        n_z, n_y, n_x = volume.shape
+        with h5py.File(path, "r") as f:
+            group = f["DataSet/ResolutionLevel 0/TimePoint 0/Channel 0"]
+            data = group["Data"]
+            chunks = data.chunks
+            for axis, size in enumerate((n_z, n_y, n_x)):
+                expected = -(-size // chunks[axis]) * chunks[axis]
+                assert data.shape[axis] == expected
+            assert int(read_attr(group, "ImageSizeX")) == n_x
+            assert int(read_attr(group, "ImageSizeY")) == n_y
+            assert int(read_attr(group, "ImageSizeZ")) == n_z
+
+    def test_histogram_is_256_bin_uint64(self, written):
+        path, volume = written
+        with h5py.File(path, "r") as f:
+            group = f["DataSet/ResolutionLevel 0/TimePoint 0/Channel 0"]
+            hist = group["Histogram"]
+            assert hist.shape == (256,)
+            assert hist.dtype == np.uint64
+            # Every voxel must be accounted for.
+            assert hist[:].sum() == volume.size
+            assert float(read_attr(group, "HistogramMin")) <= volume.min()
+            assert float(read_attr(group, "HistogramMax")) >= volume.max()
+
+    def test_pyramid_levels_are_written_for_every_tc(self, tmp_path):
+        # Large enough to force more than one resolution level.
+        rng = np.random.default_rng(1)
+        big = rng.integers(0, 1000, size=(32, 256, 256), dtype=np.uint16)
+        path = tmp_path / "pyramid.ims"
+        with ImsWriter(path, shape_tczyx=(1, 1, *big.shape), dtype=big.dtype,
+                       voxel_size_zyx=(1.0, 1.0, 1.0)) as writer:
+            levels = writer.levels
+            writer.write_volume(0, 0, big)
+
+        assert len(levels) > 1
+        with h5py.File(path, "r") as f:
+            assert len(f["DataSet"]) == len(levels)
+            for r, level_shape in enumerate(levels):
+                group = f[f"DataSet/ResolutionLevel {r}/TimePoint 0/Channel 0"]
+                assert int(read_attr(group, "ImageSizeZ")) == level_shape[0]
+                assert int(read_attr(group, "ImageSizeY")) == level_shape[1]
+                assert int(read_attr(group, "ImageSizeX")) == level_shape[2]
+
+    def test_downsampling_averages_rather_than_subsamples(self, tmp_path):
+        """
+        A volume that is zero everywhere except alternating planes would vanish
+        under naive striding; averaging must preserve the signal as a halved
+        intensity.
+        """
+        vol = np.zeros((32, 256, 256), dtype=np.uint16)
+        vol[::2] = 100
+        path = tmp_path / "mean.ims"
+        with ImsWriter(path, shape_tczyx=(1, 1, *vol.shape), dtype=vol.dtype,
+                       voxel_size_zyx=(1.0, 1.0, 1.0)) as writer:
+            levels = writer.levels
+            writer.write_volume(0, 0, vol)
+
+        # Find a level that actually reduced Z.
+        reduced = next((r for r, lv in enumerate(levels) if lv[0] < levels[0][0]), None)
+        if reduced is None:
+            pytest.skip("Pyramid did not reduce Z for this shape")
+        with h5py.File(path, "r") as f:
+            group = f[f"DataSet/ResolutionLevel {reduced}/TimePoint 0/Channel 0"]
+            shape = levels[reduced]
+            data = group["Data"][:shape[0], :shape[1], :shape[2]]
+        assert data.max() > 0, "signal was lost by subsampling instead of averaging"
+        assert data.min() > 0, "every output plane should mix a bright and a dark plane"
+
+    def test_float_input_is_preserved_as_float32(self, tmp_path):
+        vol = np.linspace(0, 1, 8 * 16 * 16, dtype=np.float64).reshape(8, 16, 16)
+        path = tmp_path / "float.ims"
+        with ImsWriter(path, shape_tczyx=(1, 1, *vol.shape), dtype=vol.dtype,
+                       voxel_size_zyx=(1.0, 1.0, 1.0)) as writer:
+            writer.write_volume(0, 0, vol)
+        with h5py.File(path, "r") as f:
+            data = f["DataSet/ResolutionLevel 0/TimePoint 0/Channel 0/Data"]
+            assert data.dtype == np.float32
+            np.testing.assert_allclose(data[:8, :16, :16], vol, rtol=1e-6)
+
+    def test_nan_becomes_zero_for_integer_output(self, tmp_path):
+        vol = np.zeros((4, 8, 8), dtype=np.float32)
+        vol[0, 0, 0] = np.nan
+        vol[1, 1, 1] = 5.0
+        path = tmp_path / "nan.ims"
+        with ImsWriter(path, shape_tczyx=(1, 1, *vol.shape), dtype=np.uint16,
+                       voxel_size_zyx=(1.0, 1.0, 1.0)) as writer:
+            writer.write_volume(0, 0, vol)
+        with h5py.File(path, "r") as f:
+            data = f["DataSet/ResolutionLevel 0/TimePoint 0/Channel 0/Data"]
+            assert data[0, 0, 0] == 0
+            assert data[1, 1, 1] == 5
+
+    def test_out_of_range_indices_rejected(self, tmp_path, volume):
+        path = tmp_path / "bounds.ims"
+        with ImsWriter(path, shape_tczyx=(1, 1, *volume.shape), dtype=volume.dtype,
+                       voxel_size_zyx=(1.0, 1.0, 1.0)) as writer:
+            with pytest.raises(IndexError):
+                writer.write_volume(1, 0, volume)
+            with pytest.raises(IndexError):
+                writer.write_volume(0, 1, volume)
+            with pytest.raises(ValueError):
+                writer.write_volume(0, 0, volume[:, :, :-1])
+            writer.write_volume(0, 0, volume)
+
+
+class TestWiring:
+    """The enum, extension and writer lookup have to agree, or a run picks the
+    right format but writes it under the wrong name."""
+
+    def test_save_type_selects_the_imaris_writer(self):
+        from lls_core.models.output import SaveFileType
+        from lls_core.writers import ImarisWriter
+
+        assert SaveFileType.imaris == "imaris"
+
+        class FakeOutput:
+            save_type = SaveFileType.imaris
+
+        from lls_core.models.lattice_data import LatticeData
+        from lls_core.models.output import OutputParams
+
+        assert OutputParams.file_extension.fget(FakeOutput()) == "ims"
+        assert LatticeData.get_writer(FakeOutput()) is ImarisWriter
+
+
+def test_readable_by_imaris_ims_file_reader(written):
+    """
+    Cross-check against an independent third-party reader if it is installed.
+    Skipped when it is not, so this never blocks the suite.
+    """
+    ims = pytest.importorskip("imaris_ims_file_reader.ims").ims
+    path, volume = written
+    n_z, n_y, n_x = volume.shape
+    image = ims(str(path))
+    assert image.ResolutionLevels == len(optimal_image_pyramid(volume.shape, 2))
+    assert image.TimePoints == 2
+    assert image.Channels == 2
+    assert image.shape[-3:] == (n_z, n_y, n_x)
+    np.testing.assert_array_equal(np.asarray(image[0, 0])[:n_z, :n_y, :n_x], volume)

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -735,7 +735,8 @@ class OutputFields(NapariFieldGroup):
     )
     save_type = field(SaveFileType).with_options(
         label = "Save Format",
-        tooltip="'tiff' is saved as a compressed OME-TIFF (.ome.tif).",
+        tooltip="'tiff' is saved as a compressed OME-TIFF (.ome.tif). "
+                "'imaris' is a multi-resolution Imaris-compatible file (.ims).",
     )
     save_path = field(Path).with_options(
         label = "Save Directory",


### PR DESCRIPTION
Large 3D dataset workflows typically use Imaris for visualization and analysis.
Adding an imaris can bypass the extra step of conversion and deliver a format ready to be used in Imaris. Besides, Fiji has an imaris reader and so does Python. 

Although there is PyImarisWriter its a Python wrapper for ImarisWriter with a windows only binary. It requires  Windows libraries and requires extra configuration in Linux and MacOS. Instead, we have created a python implementation as imaris  files are plain HDF5 with a specific layout
