### PR TITLE
Fix parallel ROI issue

### DIFF
--- a/core/lls_core/estimate.py
+++ b/core/lls_core/estimate.py
@@ -104,16 +104,16 @@ class MemoryEstimate:
     @property
     def recommended_workers(self) -> int:
         """Largest worker count that fits all caps (VRAM, host RAM, ROI count,
-        SLURM CPUs). Returns 0 if any ROI violates the per-buffer cap, which no
-        worker count can fix."""
+        CPUs). Returns 0 if any ROI violates the per-buffer cap, which no worker
+        count can fix."""
         if not self.rois:
             return 1
         if self.per_buffer_violators:
             return 0
         ceiling = len(self.rois)  # never more workers than ROIs
-        slurm_cpus = _slurm_cpu_cap()
-        if slurm_cpus is not None:
-            ceiling = min(ceiling, slurm_cpus)
+        for cpus in (_slurm_cpu_cap(), _local_cpu_cap()):
+            if cpus is not None:
+                ceiling = min(ceiling, cpus)
         gpu_budget = self.gpu_budget_bytes
         host_budget = self.host_available_bytes
         n = 1
@@ -273,6 +273,15 @@ def _slurm_cpu_cap() -> Optional[int]:
         return int(val)
     except ValueError:
         return None
+
+
+def _local_cpu_cap() -> Optional[int]:
+    """
+    Bound the recommended worker count by the machine's cores. Each worker is a whole
+    process doing GPU work, so more of them than cores just adds contention - and
+    memory alone permits one per ROI, which on many small ROIs is far too many.
+    """
+    return os.cpu_count()
 
 
 # -- Per-ROI bbox math (pixel-free) ------------------------------------------

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -54,15 +54,20 @@ def _run_roi_chunk(lattice: "LatticeData", roi_indices: list) -> None:
     sub_lattice.save()
 
 
+def _is_lazy(image: Any) -> bool:
+    """Whether an image is dask-backed, i.e. its pixels have not been read yet."""
+    import dask.array as da
+    return isinstance(getattr(image, "data", None), da.Array)
+
+
 def _materialized_image(image: Any) -> Any:
     """
-    Return a picklable, in-memory version of an input image. A lazy/dask-backed
-    array (e.g. a napari layer holding a bioio reader) is not picklable and must be
-    computed once before being sent to worker processes. A numpy-backed array is
-    already picklable and is returned unchanged.
+    Compute a lazy image so it can be pickled to workers; pass numpy through.
+
+    Only for small images (PSFs) - the input image is never materialized, see
+    `_input_reaches_workers`.
     """
-    import dask.array as da
-    if isinstance(getattr(image, "data", None), da.Array):
+    if _is_lazy(image):
         return image.copy(data=image.data.compute())
     return image
 
@@ -651,16 +656,25 @@ class LatticeData(OutputParams, DeskewParams):
                 estimate = estimate_pipeline(self, n_workers=1, safety_factor=self.memory_safety_factor)
             return max(1, estimate.recommended_workers)
         except Exception:
-            logger.debug("Auto worker estimate failed; running serially", exc_info=True)
+            logger.warning(
+                "Could not estimate a memory-safe worker count; running serially. "
+                "Pass an explicit process_parallel to override.", exc_info=True
+            )
             return 1
 
     def _use_parallel_roi_processing(self) -> bool:
-        """Return True when the parallel-ROI save path should be used."""
+        """
+        Return True when the parallel-ROI save path should be used. Every route back
+        to serial logs why: silence reads as "parallel ran and didn't help".
+        """
         if not self.cropping_enabled or self.crop is None:
             return False
         if len(self.crop.roi_subset) <= 1:
             return False
         if self._resolve_worker_count() <= 1:
+            if self.process_parallel != 1:
+                # Not what was asked for: 'auto' sized itself down to one worker.
+                logger.info("Running ROIs serially: the resolved worker count is 1.")
             return False
         if self.workflow is not None and not self._workflow_is_picklable():
             # Workers run in spawned processes, so the workflow must pickle.
@@ -669,6 +683,105 @@ class LatticeData(OutputParams, DeskewParams):
                 "process_parallel was set but the attached workflow is not "
                 "picklable (e.g. lambdas or custom modules); falling back to "
                 "serial ROI processing."
+            )
+            return False
+        if not self._input_reaches_workers():
+            return False
+        return True
+
+    def _input_reaches_workers(self) -> bool:
+        """
+        Whether the input image can reach worker processes at all: in-memory images
+        are pickled, lazy ones are re-opened from their file.
+
+        Computing a lazy image to pickle it instead would read the whole volume into
+        the parent and copy it to every worker - on a 300 GB file that never finishes.
+        """
+        if not _is_lazy(self.input_image):
+            return True
+        if self._reload_reproduces_input():
+            return True
+        logger.warning(
+            "Parallel ROI processing needs each worker to re-open the source file, "
+            "which is not possible for this image - it has no single source file, or "
+            "re-opening it does not reproduce the loaded image. Falling back to serial "
+            "ROI processing."
+        )
+        return False
+
+    def _reload_reproduces_input(self) -> bool:
+        """
+        Whether re-opening `input_image_path` yields the array this lattice holds.
+        Workers get the path, not the pixels, so a reload that differs is silently
+        wrong data.
+
+        Matching axes and dtype are not enough: the plugin concatenates one layer per
+        channel in layer-list order, and multi-scene files give several layers the same
+        path. Both can match in shape and differ in content, so sample pixels too.
+        """
+        import numpy as np
+
+        from lls_core.models.deskew import load_image_lazy
+
+        if self.input_image_path is None:
+            return False
+        try:
+            reopened = load_image_lazy(self.input_image_path)
+        except Exception:
+            logger.warning(
+                "Could not re-open %s to check it against the loaded image",
+                self.input_image_path, exc_info=True
+            )
+            return False
+
+        mine = self.input_image
+        # By named axis, not position: the plugin builds CTZYX where a reload is TCZYX,
+        # and the pipeline addresses axes by name, so that is not a mismatch.
+        if dict(reopened.sizes) != dict(mine.sizes) or reopened.dtype != mine.dtype:
+            logger.info(
+                "Re-opening %s gives %s (%s), but the loaded image is %s (%s)",
+                self.input_image_path, dict(reopened.sizes), reopened.dtype,
+                dict(mine.sizes), mine.dtype
+            )
+            return False
+
+        index = {}
+        if "T" in mine.dims:
+            index["T"] = 0
+        if "Z" in mine.dims:
+            index["Z"] = mine.sizes["Z"] // 2
+        channels = range(mine.sizes["C"]) if "C" in mine.dims else [None]
+
+        def sampled(image, at: dict):
+            # Sorted dims, so both planes come out laid out the same way.
+            plane = image.isel(**at)
+            return np.asarray(plane.transpose(*sorted(plane.dims)))
+
+        varies = False
+        for channel in channels:
+            plane = index if channel is None else {**index, "C": channel}
+            try:
+                mine_plane = sampled(mine, plane)
+                reopened_plane = sampled(reopened, plane)
+            except Exception:
+                logger.warning(
+                    "Could not read a plane to compare %s against the loaded image",
+                    self.input_image_path, exc_info=True
+                )
+                return False
+            if not np.array_equal(mine_plane, reopened_plane):
+                logger.info(
+                    "Re-opening %s gives different pixels than the loaded image "
+                    "(channel %s)", self.input_image_path, channel
+                )
+                return False
+            varies = varies or bool(mine_plane.min() != mine_plane.max())
+
+        if not varies:
+            # Flat planes match anything, so their equality proves nothing.
+            logger.info(
+                "The planes sampled from %s are uniform, so they cannot confirm the "
+                "channels match", self.input_image_path
             )
             return False
         return True
@@ -685,17 +798,11 @@ class LatticeData(OutputParams, DeskewParams):
         """
         Return a picklable copy of this lattice to hand to worker processes.
 
-        A file-backed `input_image` is a lazy bioio reader that cannot be pickled
-        (and would copy the whole volume to every worker even if it could). When the
-        source path is known, strip the image and let each worker re-open the file and
-        read only its own crops. Otherwise the input is in-memory (e.g. a napari
-        layer): materialize any lazy/dask array once so it can be pickled. A PSF loaded
-        from a path is a lazy reader too; PSFs are small, so materialize them as well.
+        A lazy `input_image` is stripped so each worker re-opens the file and reads
+        only its own crops; `_input_reaches_workers` has already verified that reload.
+        An in-memory image is pickled as-is. PSFs are small, so materialize those.
         """
-        if self.input_image_path is not None:
-            payload = self.copy(update={"input_image": None})
-        else:
-            payload = self.copy(update={"input_image": _materialized_image(self.input_image)})
+        payload = self.copy(update={"input_image": None}) if _is_lazy(self.input_image) else self.copy()
 
         if payload.deconvolution is not None:
             payload = payload.copy(update={

--- a/core/tests/test_parallel_processing.py
+++ b/core/tests/test_parallel_processing.py
@@ -315,17 +315,16 @@ def _assert_same_output_images(ser_dir: str, par_dir: str) -> None:
 
 
 @pytest.mark.parametrize("make_kwargs", [
-    pytest.param(_numpy_kwargs, id="numpy_materialize"),
+    pytest.param(_numpy_kwargs, id="numpy_pickled"),
     pytest.param(_file_path_kwargs, id="file_path_lazy_reload"),
-    pytest.param(_dask_no_path_kwargs, id="dask_no_path_materialize"),
+    pytest.param(_dask_no_path_kwargs, id="dask_no_path_serial_fallback"),
 ])
 def test_parallel_save_matches_serial(make_kwargs, rbc_tiny):
     """
-    Parallel ROI save must match serial across input variants:
-    in-memory numpy (materialize passthrough), a file path (lazy per-crop reload),
-    and an in-memory dask array with no path (materialize). The numpy-only case
-    would pickle fine and hide the unpicklable lazy-reader bugs, hence the file
-    and dask variants.
+    Parallel ROI save must match serial across input variants: in-memory numpy
+    (pickled to workers), a file path (lazy per-crop reload), and a lazy array with
+    no path (which falls back to serial). The numpy-only case would pickle fine and
+    hide the unpicklable lazy-reader bugs, hence the other two.
     """
     def build(save_dir: str, parallel: int) -> LatticeData:
         return LatticeData(
@@ -382,6 +381,97 @@ def test_use_parallel_falls_back_when_single_roi():
         lattice = _make_lattice(raw, roi, tmpdir, process_parallel=4)
         # With only one ROI we should not bother spinning up workers
         assert lattice._use_parallel_roi_processing() is False
+
+
+# --- dispatching a lazy input to workers ------------------------------------
+
+def _lazy_like(reference, fill):
+    """A lazy DataArray with `reference`'s dims, shape and dtype, holding `fill`."""
+    import dask.array as da
+    raw = np.asarray(fill, dtype=reference.dtype)
+    if raw.ndim == 0:
+        raw = np.full(reference.shape, raw, dtype=reference.dtype)
+    return DataArray(da.from_array(raw), dims=list(reference.dims))
+
+
+def _lattice_over(image, path, tmpdir, parallel=2):
+    return LatticeData(
+        input_image=image, input_image_path=path,
+        physical_pixel_sizes=(1, 1, 1),
+        save_name="v", save_dir=tmpdir, save_type="tiff",
+        crop=CropParams(roi_list=[_roi(0, 0, 60, 60), _roi(20, 20, 100, 100)], z_range=(0, 5)),
+        process_parallel=parallel,
+    )
+
+
+def test_lazy_input_without_a_path_is_never_materialized(rbc_tiny, monkeypatch):
+    """
+    Regression for the GUI hang: with no re-openable path, the dispatcher called
+    .compute() on the whole lazy volume before starting any worker - on a 300 GB file
+    that never returns, at 100% CPU, with nothing saved. Materializing is now never how
+    the input reaches workers, so the run completes even when doing so is an error.
+    """
+    from lls_core.models import lattice_data as ld
+
+    def explode(image):
+        raise AssertionError("the input image was materialized")
+
+    monkeypatch.setattr(ld, "_materialized_image", explode)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = LatticeData(**_dask_no_path_kwargs(rbc_tiny), save_name="v",
+                              save_dir=tmpdir, save_type="tiff", process_parallel=2)
+        assert lattice.input_image_path is None
+        assert lattice._use_parallel_roi_processing() is False
+        lattice.save()
+        assert sorted(p.name for p in Path(tmpdir).iterdir())
+
+
+def test_reload_check_accepts_the_source_file(rbc_tiny):
+    """The ordinary case: workers re-opening the file do get the parent's array."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = LatticeData(**_file_path_kwargs(rbc_tiny), save_name="v",
+                              save_dir=tmpdir, save_type="tiff", process_parallel=2)
+        assert lattice._reload_reproduces_input() is True
+        assert lattice._use_parallel_roi_processing() is True
+
+
+def test_reload_check_rejects_different_pixels(rbc_tiny):
+    """
+    Matching axes and dtype are not enough: the plugin concatenates one layer per
+    channel in layer-list order, so a reload can be the same shape with its channels
+    in a different order - right shape, wrong image, saved without any error.
+    """
+    from lls_core.models.deskew import load_image_lazy
+
+    reference = load_image_lazy(Path(str(rbc_tiny)))
+    varied = np.zeros(reference.shape, dtype=reference.dtype)
+    varied[..., ::2] = 3          # differs from the file, but not a flat plane
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = _lattice_over(_lazy_like(reference, varied), Path(str(rbc_tiny)), tmpdir)
+        assert lattice._reload_reproduces_input() is False
+        assert lattice._use_parallel_roi_processing() is False
+
+
+def test_reload_check_declines_when_sampled_planes_are_uniform(tmp_path, caplog):
+    """A flat plane matches any other, so matching ones prove nothing. Decline."""
+    import logging
+
+    import tifffile
+
+    from lls_core.models.deskew import load_image_lazy
+
+    blank = tmp_path / "blank.tif"
+    tifffile.imwrite(str(blank), np.zeros((30, 120, 120), dtype=np.uint16))
+    reference = load_image_lazy(blank)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Identical pixels to the file, so only the uniformity check can reject it.
+        lattice = _lattice_over(_lazy_like(reference, 0), blank, tmpdir)
+        with caplog.at_level(logging.INFO, logger="lls_core.models.lattice_data"):
+            assert lattice._reload_reproduces_input() is False
+    assert any("uniform" in r.getMessage() for r in caplog.records), caplog.records
 
 
 def test_dispatch_payload_materializes_lazy_psf():

--- a/core/tests/test_parallel_processing.py
+++ b/core/tests/test_parallel_processing.py
@@ -163,6 +163,18 @@ def test_slurm_cpu_cap_respected_in_recommendation(monkeypatch):
     assert est.recommended_workers <= 2
 
 
+def test_local_cpu_cap_respected_in_recommendation(monkeypatch):
+    # Memory alone allows one worker per ROI, which on a machine with fewer cores is
+    # just contention: each worker is a whole process doing GPU work.
+    from lls_core import estimate as est_mod
+    monkeypatch.setattr(est_mod, "_local_cpu_cap", lambda: 2)
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    rois = [[[0, 0], [0, 20], [20, 20], [20, 0]]] * 6
+    with tempfile.TemporaryDirectory() as tmpdir:
+        est = estimate_pipeline(_make_lattice(raw, rois, tmpdir), n_workers=8)
+    assert est.recommended_workers == 2
+
+
 def test_estimate_pipeline_safety_factor_scales_working_set():
     raw = np.zeros((30, 50, 50), dtype=np.uint16)
     roi = [[[0, 0], [0, 40], [40, 40], [40, 0]]]

--- a/plugin/napari_lattice/reader.py
+++ b/plugin/napari_lattice/reader.py
@@ -58,9 +58,9 @@ class NapariImageParams(TypedDict):
     data: DataArray
     physical_pixel_sizes: DefinedPixelSizes
     save_name: str
-    # Source file path, set only for a single unmodified file-backed layer, so that
-    # parallel workers can re-open the file and lazily read only their ROI crops
-    # (instead of materializing the whole volume). None for stacked/derived/in-memory.
+    # Source file shared by every selected layer, so that parallel workers can re-open
+    # it and lazily read only their ROI crops. None when the layers came from more than
+    # one file, from no file at all, or were reinterpreted with a manual dimension order.
     input_image_path: Optional[Path]
 
 def lattice_params_from_napari(
@@ -150,14 +150,18 @@ def lattice_params_from_napari(
 
     final_img = concat(final_imgs, dim=stack_along)
 
-    # Only a single, unmodified file-backed layer can be safely re-opened from its
-    # path in a worker and reproduce the same array. Skip stacked layers (no single
-    # source) and any layer with a user-overridden dimension order (the reload uses
-    # metadata dims, which may then differ). Otherwise -> materialize.
+    # Record the source file so parallel workers can re-open it and read only their own
+    # crops. A multi-channel file arrives as one layer per channel, so several layers
+    # sharing one path still count; layers from different files, or a user-overridden
+    # dimension order (the reload uses metadata dims), do not. Necessary but not
+    # sufficient - `LatticeData` verifies the reload before any worker relies on it.
     imgs_seq = list(imgs)
     input_image_path: Optional[Path] = None
-    if len(imgs_seq) == 1 and dimension_order is None and imgs_seq[0].source.path is not None:
-        input_image_path = Path(imgs_seq[0].source.path)
+    source_paths = {img.source.path for img in imgs_seq}
+    if dimension_order is None and len(source_paths) == 1:
+        only_path = source_paths.pop()
+        if only_path is not None:
+            input_image_path = Path(only_path)
 
     return NapariImageParams(save_name=save_names[0], physical_pixel_sizes=final_pixel_size, data=final_img, dims=final_img.shape, input_image_path=input_image_path)
 

--- a/plugin/tests/test_reader.py
+++ b/plugin/tests/test_reader.py
@@ -11,6 +11,8 @@ needs to correct the interpretation.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 import tifffile
@@ -53,6 +55,69 @@ def test_genuine_multichannel_is_split():
     assert add_kwargs["name"] == list(image.channel_names)
     # The channel axis is dropped from the per-channel dimension metadata.
     assert "C" not in add_kwargs["metadata"]["dimensions"]
+
+
+def _open_layers(viewer, path):
+    viewer.open(str(path), plugin="napari-lattice")
+    return list(viewer.layers)
+
+
+def test_channel_layers_of_one_file_keep_its_path(make_napari_viewer):
+    """
+    A multi-channel file arrives as one layer per channel. Selecting them all used to
+    drop the path, since only a lone layer counted as re-openable; the dispatcher then
+    computed the whole lazy volume, which on a large file never finishes.
+    """
+    from napari_lattice.reader import lattice_params_from_napari
+
+    viewer = make_napari_viewer()
+    with as_file(resources / "LLS7_t1_ch3.czi") as p:
+        layers = _open_layers(viewer, p)
+        assert len(layers) > 1, "expected this file to split into per-channel layers"
+        params = lattice_params_from_napari(imgs=layers, stack_along="C")
+        assert params["input_image_path"] == Path(str(p))
+
+
+def test_layers_from_different_files_have_no_single_path(make_napari_viewer, tmp_path):
+    # Two sources, so no one file can be re-opened to reproduce the stack. A copy of
+    # the same image keeps the layers stackable, isolating the path check.
+    import shutil
+
+    from napari_lattice.reader import lattice_params_from_napari
+
+    viewer = make_napari_viewer()
+    with as_file(resources / "LLS7_t1_ch1.czi") as original:
+        copy = tmp_path / "copy.czi"
+        shutil.copy(original, copy)
+        _open_layers(viewer, original)
+        layers = _open_layers(viewer, copy)
+        assert len({lyr.source.path for lyr in layers}) == 2
+        params = lattice_params_from_napari(imgs=layers, stack_along="C")
+    assert params["input_image_path"] is None
+
+
+@pytest.mark.parametrize("reverse", [False, True], ids=["file_order", "reversed"])
+def test_reload_verification_is_sensitive_to_layer_order(make_napari_viewer, tmp_path, reverse):
+    """
+    Channels are concatenated in layer-list order, which need not be the file's, so the
+    path alone cannot tell a worker how to rebuild the parent's array. Reordered layers
+    must be rejected, or workers save the right shape with the wrong channels, silently.
+    """
+    from lls_core.models.lattice_data import LatticeData
+    from napari_lattice.reader import lattice_params_from_napari
+
+    viewer = make_napari_viewer()
+    with as_file(resources / "LLS7_t1_ch3.czi") as p:
+        layers = _open_layers(viewer, p)
+        params = lattice_params_from_napari(
+            imgs=layers[::-1] if reverse else layers, stack_along="C"
+        )
+        lattice = LatticeData(
+            input_image=params["data"], input_image_path=params["input_image_path"],
+            physical_pixel_sizes=params["physical_pixel_sizes"],
+            save_name="v", save_dir=str(tmp_path), save_type="tiff",
+        )
+        assert lattice._reload_reproduces_input() is (not reverse)
 
 
 def test_single_channel_tiff_yields_5d_dimension_options(tmp_path):


### PR DESCRIPTION
A multi-channel file opens as one napari layer per channel. The source path was only recorded for a *single* layer, so selecting all channels dropped it,  and the dispatcher then called `.compute()` on the whole lazy volume before starting any worker. On a large CZi file (70 GB) that pinned the CPU indefinitely and saved nothing; serial processing worked fine, and took under a minute.

- Keep the path when all selected layers come from one file.
- Never compute/materialize the input: workers get it pickled (in memory) or re-opened from file   (lazy). If not possible default to sequential with a warning.
- Verify the reload first - layer order and multi-scene files can match in shape but not   in pixels, which would silently save the wrong channels.
- Cap auto worker count by CPU count (was bounded only by ROIs, memory and SLURM).
- Log serial fallbacks that were previously silent.