### PR TITLE
fixing bugs with roi import units

### DIFF
--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -85,24 +85,12 @@ def field_from_model(model: Type[FieldAccessModel], field_name: str, extra_descr
     )
 
 class RoiUnitsChoice(click.Choice):
-    """
-    ``--roi-units`` accepting any case and either singular or plural, while ``--help``
-    still lists the canonical names. Click resolves choices before a callback runs, so
-    the spellings have to be handled by the type itself.
-    """
-    def __init__(self) -> None:
-        super().__init__([unit.value for unit in RoiUnits], case_sensitive=False)
+    """`--roi-units pixel` as well as `pixels`, in any case."""
 
-    def convert(self, value: Any, param: Any, ctx: Any) -> RoiUnits:
-        try:
-            return RoiUnits(value)
-        except ValueError:
-            self.fail(
-                f"{value!r} is not a valid ROI unit. Choose from "
-                f"{', '.join(unit.value for unit in RoiUnits)} (case-insensitive, "
-                "singular or plural).",
-                param, ctx,
-            )
+    def normalize_choice(self, choice: Any, ctx: Any) -> str:
+        # Click runs this over the declared choices and the typed value alike, so
+        # folding away a trailing "s" makes the two spellings the same token.
+        return super().normalize_choice(choice, ctx).rstrip("s")
 
 
 def parse_roi_subset(value: Optional[List[str]]) -> Optional[List[int]]:
@@ -201,7 +189,10 @@ def process(
     )),
 
     roi_list: List[Path] = field_from_model(CropParams, "roi_list"),
-    roi_units: RoiUnits = field_from_model(CropParams, "roi_units", click_type=RoiUnitsChoice()),
+    roi_units: RoiUnits = field_from_model(
+        CropParams, "roi_units",
+        click_type=RoiUnitsChoice([unit.value for unit in RoiUnits], case_sensitive=False),
+    ),
     roi_subset: List[str] = field_from_model(CropParams, "roi_subset", extra_description="Accepts either repeated flags (--roi-subset 2 --roi-subset 5) or a comma-separated list (--roi-subset 2,5,7).", default=[], callback=parse_roi_subset),
     z_range: Optional[Tuple[int,int]] = field_from_model(CropParams, "z_range", show_default=False),
     

--- a/core/lls_core/cmds/__main__.py
+++ b/core/lls_core/cmds/__main__.py
@@ -84,6 +84,27 @@ def field_from_model(model: Type[FieldAccessModel], field_name: str, extra_descr
         **kwargs
     )
 
+class RoiUnitsChoice(click.Choice):
+    """
+    ``--roi-units`` accepting any case and either singular or plural, while ``--help``
+    still lists the canonical names. Click resolves choices before a callback runs, so
+    the spellings have to be handled by the type itself.
+    """
+    def __init__(self) -> None:
+        super().__init__([unit.value for unit in RoiUnits], case_sensitive=False)
+
+    def convert(self, value: Any, param: Any, ctx: Any) -> RoiUnits:
+        try:
+            return RoiUnits(value)
+        except ValueError:
+            self.fail(
+                f"{value!r} is not a valid ROI unit. Choose from "
+                f"{', '.join(unit.value for unit in RoiUnits)} (case-insensitive, "
+                "singular or plural).",
+                param, ctx,
+            )
+
+
 def parse_roi_subset(value: Optional[List[str]]) -> Optional[List[int]]:
     """
     Typer callback  normalises ``--roi-subset`` into a flat list of integer
@@ -180,7 +201,7 @@ def process(
     )),
 
     roi_list: List[Path] = field_from_model(CropParams, "roi_list"),
-    roi_units: RoiUnits = field_from_model(CropParams, "roi_units"),
+    roi_units: RoiUnits = field_from_model(CropParams, "roi_units", click_type=RoiUnitsChoice()),
     roi_subset: List[str] = field_from_model(CropParams, "roi_subset", extra_description="Accepts either repeated flags (--roi-subset 2 --roi-subset 5) or a comma-separated list (--roi-subset 2,5,7).", default=[], callback=parse_roi_subset),
     z_range: Optional[Tuple[int,int]] = field_from_model(CropParams, "z_range", show_default=False),
     

--- a/core/lls_core/cropping.py
+++ b/core/lls_core/cropping.py
@@ -25,6 +25,22 @@ class RoiUnits(StrEnum):
     Pixels = "Pixels"
     Microns = "Microns"
 
+    @classmethod
+    def _missing_(cls, value: object) -> "RoiUnits | None":
+        # Accept the spellings people actually type: any case, singular or plural.
+        if isinstance(value, str):
+            return _ROI_UNIT_ALIASES.get(value.strip().lower())
+        return None
+
+
+_ROI_UNIT_ALIASES = {
+    "auto": RoiUnits.Auto,
+    "pixel": RoiUnits.Pixels,
+    "pixels": RoiUnits.Pixels,
+    "micron": RoiUnits.Microns,
+    "microns": RoiUnits.Microns,
+}
+
 
 def units_for_path(roi_path: PathLike) -> RoiUnits:
     """

--- a/core/lls_core/cropping.py
+++ b/core/lls_core/cropping.py
@@ -25,22 +25,6 @@ class RoiUnits(StrEnum):
     Pixels = "Pixels"
     Microns = "Microns"
 
-    @classmethod
-    def _missing_(cls, value: object) -> "RoiUnits | None":
-        # Accept the spellings people actually type: any case, singular or plural.
-        if isinstance(value, str):
-            return _ROI_UNIT_ALIASES.get(value.strip().lower())
-        return None
-
-
-_ROI_UNIT_ALIASES = {
-    "auto": RoiUnits.Auto,
-    "pixel": RoiUnits.Pixels,
-    "pixels": RoiUnits.Pixels,
-    "micron": RoiUnits.Microns,
-    "microns": RoiUnits.Microns,
-}
-
 
 def units_for_path(roi_path: PathLike) -> RoiUnits:
     """

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -199,6 +199,29 @@ class LatticeData(OutputParams, DeskewParams):
         return v
 
     @validator("crop")
+    def warn_rois_outside_image(cls, v: Optional[CropParams], values: dict) -> Optional[CropParams]:
+        """
+        Say so when an ROI lies outside the deskewed image. Usually it means the units
+        were wrong, and the alternative is a crop failing later inside the writer with
+        an unrelated-looking message.
+        """
+        from lls_core.models.utils import ignore_keyerror
+
+        if v is None or not v.roi_list:
+            return v
+        with ignore_keyerror():
+            height, width = values["derived"].deskew_vol_shape[1:]
+            worst_y = max(y for roi in v.roi_list for y, _ in roi)
+            worst_x = max(x for roi in v.roi_list for _, x in roi)
+            if worst_y > height or worst_x > width:
+                logger.warning(
+                    "ROIs extend to (%.0f, %.0f) but the deskewed image is only "
+                    "(%d, %d) pixels. Check roi_units: coordinates in the wrong unit "
+                    "are out by the pixel size.", worst_y, worst_x, height, width
+                )
+        return v
+
+    @validator("crop")
     def default_z_range(cls, v: Optional[CropParams], values: dict) -> Optional[CropParams]:
         from lls_core.models.utils import ignore_keyerror
         if v is None:

--- a/core/tests/test_roi_units.py
+++ b/core/tests/test_roi_units.py
@@ -112,24 +112,27 @@ def test_auto_takes_the_unit_from_the_file_type(tmp_path):
     assert lattice.crop.roi_list == scale_rois(read_napari_csv(csv), 2.0)
 
 
-@pytest.mark.parametrize("given, expected", [
-    ("pixels", RoiUnits.Pixels), ("Pixels", RoiUnits.Pixels),
-    ("PIXEL", RoiUnits.Pixels), (" pixel ", RoiUnits.Pixels),
-    ("microns", RoiUnits.Microns), ("Micron", RoiUnits.Microns),
-    ("MICRONS", RoiUnits.Microns), ("auto", RoiUnits.Auto),
-])
-def test_unit_names_are_case_and_plural_insensitive(given, expected):
-    assert RoiUnits(given) is expected
+@pytest.mark.parametrize("given", ["pixels", "Pixels", "PIXEL", "pixel"])
+def test_cli_accepts_either_spelling_of_a_unit(given):
+    from lls_core.cmds.__main__ import RoiUnitsChoice
+
+    choice = RoiUnitsChoice([unit.value for unit in RoiUnits], case_sensitive=False)
+    assert choice.convert(given, None, None) == RoiUnits.Pixels
 
 
-def test_an_unknown_unit_name_is_still_rejected():
-    with pytest.raises(ValueError):
-        RoiUnits("furlongs")
+def test_cli_still_rejects_an_unknown_unit():
+    import click
+    from lls_core.cmds.__main__ import RoiUnitsChoice
+
+    choice = RoiUnitsChoice([unit.value for unit in RoiUnits], case_sensitive=False)
+    with pytest.raises(click.UsageError):
+        choice.convert("furlongs", None, None)
 
 
-def test_a_config_file_may_spell_the_unit_however(tmp_path):
-    # YAML/JSON configs reach the model as plain strings.
-    params = CropParams(roi_list=[ROI], roi_units="micron", z_range=(0, 5))
+def test_a_config_file_may_name_the_unit_as_a_string(tmp_path):
+    # YAML/JSON configs reach the model as plain strings. The CLI is separately
+    # case-insensitive via typer's case_sensitive=False.
+    params = CropParams(roi_list=[ROI], roi_units="Microns", z_range=(0, 5))
     assert params.roi_units is RoiUnits.Microns
 
 

--- a/core/tests/test_roi_units.py
+++ b/core/tests/test_roi_units.py
@@ -112,6 +112,27 @@ def test_auto_takes_the_unit_from_the_file_type(tmp_path):
     assert lattice.crop.roi_list == scale_rois(read_napari_csv(csv), 2.0)
 
 
+@pytest.mark.parametrize("given, expected", [
+    ("pixels", RoiUnits.Pixels), ("Pixels", RoiUnits.Pixels),
+    ("PIXEL", RoiUnits.Pixels), (" pixel ", RoiUnits.Pixels),
+    ("microns", RoiUnits.Microns), ("Micron", RoiUnits.Microns),
+    ("MICRONS", RoiUnits.Microns), ("auto", RoiUnits.Auto),
+])
+def test_unit_names_are_case_and_plural_insensitive(given, expected):
+    assert RoiUnits(given) is expected
+
+
+def test_an_unknown_unit_name_is_still_rejected():
+    with pytest.raises(ValueError):
+        RoiUnits("furlongs")
+
+
+def test_a_config_file_may_spell_the_unit_however(tmp_path):
+    # YAML/JSON configs reach the model as plain strings.
+    params = CropParams(roi_list=[ROI], roi_units="micron", z_range=(0, 5))
+    assert params.roi_units is RoiUnits.Microns
+
+
 def test_auto_with_no_files_means_pixels(tmp_path):
     # Coordinates passed directly by an API caller are pixels by convention.
     lattice = _lattice(tmp_path, [ROI], RoiUnits.Auto)
@@ -124,6 +145,19 @@ def test_auto_refuses_to_guess_across_mixed_file_types(tmp_path):
     imagej.write_bytes(b"")
     with pytest.raises(ValueError, match="set roi_units explicitly"):
         CropParams(roi_list=[_write(tmp_path, CSV), imagej], z_range=(0, 5))
+
+
+def test_rois_outside_the_image_are_called_out(tmp_path, caplog):
+    """
+    The usual cause is the wrong unit. Without this the run dies later inside the
+    writer with 'truncate can only be used with imagej or shaped formats'.
+    """
+    import logging
+
+    far = scale_rois([ROI], 100.0)
+    with caplog.at_level(logging.WARNING, logger="lls_core.models.lattice_data"):
+        _lattice(tmp_path, far, RoiUnits.Pixels)
+    assert any("roi_units" in r.getMessage() for r in caplog.records), caplog.records
 
 
 def test_conversion_does_not_repeat_when_the_model_is_revalidated(tmp_path):

--- a/core/tests/test_roi_units.py
+++ b/core/tests/test_roi_units.py
@@ -8,14 +8,12 @@ unit is declared on the way in and converted once.
 """
 from __future__ import annotations
 
-import tempfile
-
 import numpy as np
 import pytest
 from xarray import DataArray
 
 from lls_core.cropping import (
-    Roi, RoiUnits, read_napari_csv, read_rois, scale_rois, units_for_path,
+    Roi, RoiUnits, read_napari_csv, scale_rois, units_for_path,
 )
 from lls_core.models.crop import CropParams
 from lls_core.models.lattice_data import LatticeData
@@ -71,12 +69,6 @@ def test_a_csv_that_is_not_a_shapes_layer_is_rejected(tmp_path):
         read_napari_csv(_write(tmp_path, "x,y\n1,2\n"))
 
 
-def test_read_rois_routes_on_suffix(tmp_path):
-    assert read_rois(_write(tmp_path, CSV)) == read_napari_csv(_write(tmp_path, CSV))
-    with pytest.raises(Exception, match="zip/roi"):
-        read_rois(_write(tmp_path, CSV, name="shapes.txt"))
-
-
 def _lattice(tmp_path, rois, units, dy=0.5):
     return LatticeData(
         input_image=DataArray(np.zeros((30, 100, 100), dtype=np.uint16), dims=["Z", "Y", "X"]),
@@ -112,7 +104,7 @@ def test_auto_takes_the_unit_from_the_file_type(tmp_path):
     assert lattice.crop.roi_list == scale_rois(read_napari_csv(csv), 2.0)
 
 
-@pytest.mark.parametrize("given", ["pixels", "Pixels", "PIXEL", "pixel"])
+@pytest.mark.parametrize("given", ["pixels", "PIXEL"])  # canonical, then miscased singular
 def test_cli_accepts_either_spelling_of_a_unit(given):
     from lls_core.cmds.__main__ import RoiUnitsChoice
 
@@ -127,13 +119,6 @@ def test_cli_still_rejects_an_unknown_unit():
     choice = RoiUnitsChoice([unit.value for unit in RoiUnits], case_sensitive=False)
     with pytest.raises(click.UsageError):
         choice.convert("furlongs", None, None)
-
-
-def test_a_config_file_may_name_the_unit_as_a_string(tmp_path):
-    # YAML/JSON configs reach the model as plain strings. The CLI is separately
-    # case-insensitive via typer's case_sensitive=False.
-    params = CropParams(roi_list=[ROI], roi_units="Microns", z_range=(0, 5))
-    assert params.roi_units is RoiUnits.Microns
 
 
 def test_auto_with_no_files_means_pixels(tmp_path):


### PR DESCRIPTION
Minor: Ensure when ROI is imported and roi-units is specified, its case insensitive.