### PR TITLE
ci: build test environments with Miniforge

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -32,8 +32,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: conda-incubator/setup-miniconda@v3
+      # Miniforge + conda-forge only, matching the environment docs/installation.md
+      # tells users to build. Miniconda's `defaults` channel resolves different
+      # package versions, so CI was not testing what users actually install.
+      - uses: conda-incubator/setup-miniconda@v4
         with:
+          miniforge-version: latest
+          conda-remove-defaults: "true"
           auto-update-conda: true
           activate-environment: test
           python-version: ${{ matrix.python-version }}
@@ -53,10 +58,17 @@ jobs:
         run: |
           # Install dependencies
           # We include types-PyYAML here too for linux linting consistency
-          conda install -y pyqt pyopencl pocl pytest-qt 
+          # openssl 3.6.3 cannot parse DER certificates, which breaks
+          # ssl.create_default_context() and therefore every dask compute.
+          conda install -y pyqt pyopencl pocl pytest-qt "openssl!=3.6.3" 
           
           uv pip install --upgrade pip setuptools wheel
           uv pip install -e './core[testing]'
+
+      - name: Verify TLS stack
+        run: |
+          conda list openssl
+          python -c "import ssl; print(ssl.OPENSSL_VERSION); ssl.create_default_context(); import distributed; print('TLS OK')"
 
       - name: Lint core
         uses: ./.github/lint
@@ -91,8 +103,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: conda-incubator/setup-miniconda@v2
+      # Miniforge + conda-forge only, matching the environment docs/installation.md
+      # tells users to build. Miniconda's `defaults` channel resolves different
+      # package versions, so CI was not testing what users actually install.
+      - uses: conda-incubator/setup-miniconda@v4
         with:
+          miniforge-version: latest
+          conda-remove-defaults: "true"
           auto-update-conda: true
           activate-environment: test
           python-version: ${{ matrix.python-version }}
@@ -109,17 +126,29 @@ jobs:
       - name: Install core & plugin
         timeout-minutes: 10
         run: |
-          conda install -y qtpy pyopencl oclgrind pytest-qt typing-extensions
+          # openssl 3.6.3 cannot parse DER certificates, which breaks
+          # ssl.create_default_context() and therefore every dask compute.
+          conda install -y qtpy pyopencl oclgrind pytest-qt typing-extensions "openssl!=3.6.3"
           uv pip install --upgrade pip setuptools wheel
           # Install core and plugin
           uv pip install -e './core[testing]'
           uv pip install -e './plugin[testing]'
 
+      # Fails loudly here rather than inside an unrelated napari traceback. Any
+      # dask compute imports `distributed`, which builds an SSL context at import
+      # time via tornado, which reads the Windows certificate store.
+      - name: Verify TLS stack
+        run: |
+          conda list openssl
+          python -c "import ssl; print(ssl.OPENSSL_VERSION); ssl.create_default_context(); import distributed; print('TLS OK')"
+
       - name: Register oclgrind OpenCL ICD
         shell: pwsh
         run: |
           # Find oclgrind DLL
-          $dll = Get-ChildItem "C:\Miniconda\envs\test\Library\bin" -Filter "*oclgrind*" | Select-Object -First 1
+          # $CONDA is exported by setup-miniconda and points at the installation
+          # root. Do not hardcode C:\Miniconda: the Miniforge installer path differs.
+          $dll = Get-ChildItem "$env:CONDA\envs\test\Library\bin" -Filter "*oclgrind*" | Select-Object -First 1
           Write-Host "Found: $($dll.FullName)"
           $regPath = "HKLM:\SOFTWARE\Khronos\OpenCL\Vendors"
           if (-not (Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }


### PR DESCRIPTION
There was a bug using openssl 3.6.3, which led to the Windows install being broken with default conda-forge installation. 

When opening a czi file, we would get the error:
`SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4004)`

The [documentation has been updated](https://bioimageanalysiscorewehi.github.io/napari_lattice/installation/) to add a version constraint "openssl!=3.6.3"

This was invisible to our tests as we used miniconda instead of our recommendation of miniforge with conda defaults removed. 
Fixed tests so its reflective of our installation instructions