### PR TITLE
Improve GPU memory handling and user warnings

### DIFF
--- a/core/lls_core/estimate.py
+++ b/core/lls_core/estimate.py
@@ -1,23 +1,33 @@
 """
-Memory estimation for crop-deskew pipelines.
+Memory estimation for deskew pipelines.
 
-Computes per-ROI bounding boxes from the same affine math as `crop_volume_deskew`,
-without touching pixel data, to estimate whether a requested worker count fits in
-GPU and host memory before launching. Estimates are shape-and-dtype only, plus a
-safety factor for OpenCL scratch buffers and driver overhead.
+Computes output bounding boxes from the same affine math as the deskew itself,
+without touching pixel data, to estimate whether the work fits in GPU and host
+memory before launching. Estimates are shape-and-dtype only, plus a safety factor
+for OpenCL scratch buffers and driver overhead.
+
+Two shapes of estimate live here:
+
+* per-ROI (`estimate_roi`, `estimate_pipeline`), which sizes the crop-deskew path and
+  answers "how many workers fit in parallel?";
+* whole-volume (`estimate_deskew_volume`), which sizes the no-crop path, where the
+  deskewed buffer is a single allocation whose size the user never chose.
 """
 from __future__ import annotations
 
 import logging
+import math
 import os
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Generator, Iterable, List, Optional, Tuple
 
 import numpy as np
 
 from lls_core import DeskewDirection
 
 if TYPE_CHECKING:
+    from lls_core.models.deskew import DeskewParams
     from lls_core.models.lattice_data import LatticeData
 
 logger = logging.getLogger(__name__)
@@ -29,6 +39,53 @@ GPU_DTYPE_ITEMSIZE: int = 4
 # With per-buffer accounting done explicitly, the safety factor only covers
 # driver scratch and fragmentation. 1.5x is a conservative default.
 DEFAULT_SAFETY_FACTOR: float = 1.5
+
+# Headroom subtracted from total VRAM for OpenCL runtime allocations the user can't see.
+DEFAULT_GPU_RESERVE_BYTES: int = 512 * 1024 * 1024
+
+# Upstream report of the failure mode this module predicts, for maintainers:
+# https://github.com/clEsperanto/pyclesperanto_prototype/issues/344
+
+
+def _fmt_bytes(n: Optional[float]) -> str:
+    """Format a byte count for a human-readable report; `None` renders as 'unknown'."""
+    if n is None:
+        return "unknown"
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(n) < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PiB"
+
+
+@dataclass
+class DeviceLimits:
+    """The device caps every estimate is judged against, in bytes.
+
+    `gpu_max_alloc_bytes` is the per-buffer cap (CL_DEVICE_MAX_MEM_ALLOC_SIZE): a
+    single allocation above it fails however much total VRAM is free. `None` means
+    the device could not be queried, which is not evidence of a problem.
+    """
+
+    gpu_global_bytes: Optional[int]
+    gpu_max_alloc_bytes: Optional[int]
+    gpu_reserve_bytes: int
+    host_available_bytes: Optional[int]
+
+    @property
+    def gpu_budget_bytes(self) -> Optional[int]:
+        if self.gpu_global_bytes is None:
+            return None
+        return max(0, self.gpu_global_bytes - self.gpu_reserve_bytes)
+
+
+def _query_device_limits(gpu_reserve_bytes: int = DEFAULT_GPU_RESERVE_BYTES) -> DeviceLimits:
+    return DeviceLimits(
+        gpu_global_bytes=get_global_mem_size(),
+        gpu_max_alloc_bytes=get_max_allocation_size(),
+        gpu_reserve_bytes=gpu_reserve_bytes,
+        host_available_bytes=get_host_available_bytes(),
+    )
 
 
 @dataclass
@@ -67,6 +124,152 @@ class RoiEstimate:
 
 
 @dataclass
+class DeskewVolumeEstimate:
+    """Memory estimate for deskewing one whole 3D volume, in bytes.
+
+    This is the no-crop path, where the deskewed buffer is a single OpenCL
+    allocation whose size the user never picked: it grows along the shear axis,
+    so a modest raw stack can produce an output the GPU cannot allocate at all.
+    That failure surfaces as an opaque OpenCL `OUT_OF_RESOURCES` which is not very clear
+    (see `CLESPERANTO_MEMORY_ISSUE_URL`).
+    """
+
+    input_zyx: Tuple[int, int, int]
+    output_zyx: Tuple[int, int, int]
+    input_itemsize: int
+    output_itemsize: int
+    safety_factor: float
+    device: DeviceLimits
+
+    @property
+    def voxels(self) -> int:
+        return math.prod(self.output_zyx)
+
+    @property
+    def gpu_input_bytes(self) -> int:
+        return math.prod(self.input_zyx) * GPU_DTYPE_ITEMSIZE
+
+    @property
+    def gpu_output_bytes(self) -> int:
+        return self.voxels * GPU_DTYPE_ITEMSIZE
+
+    @property
+    def max_single_allocation(self) -> int:
+        """Largest single OpenCL buffer. If this exceeds CL_DEVICE_MAX_MEM_ALLOC_SIZE
+        the volume cannot be deskewed in one piece however much VRAM is free."""
+        return max(self.gpu_input_bytes, self.gpu_output_bytes)
+
+    @property
+    def gpu_working_set(self) -> int:
+        """Peak VRAM: the input and output buffers coexist for the duration of the kernel."""
+        return int((self.gpu_input_bytes + self.gpu_output_bytes) * self.safety_factor)
+
+    @property
+    def host_peak_bytes(self) -> int:
+        """Peak host RAM. The result is pulled back as float32 and then cast to the
+        output dtype, so the raw input, the pulled array and the cast copy are all
+        briefly alive at once."""
+        raw = math.prod(self.input_zyx) * self.input_itemsize
+        pulled = self.voxels * GPU_DTYPE_ITEMSIZE
+        restored = 0 if self.output_itemsize == GPU_DTYPE_ITEMSIZE else self.voxels * self.output_itemsize
+        return int((raw + pulled + restored) * self.safety_factor)
+
+    @property
+    def exceeds_max_alloc(self) -> Optional[bool]:
+        """Whether a single buffer breaks the per-allocation cap. `None` if unknown."""
+        if self.device.gpu_max_alloc_bytes is None:
+            return None
+        return self.max_single_allocation > self.device.gpu_max_alloc_bytes
+
+    @property
+    def fits_gpu(self) -> Optional[bool]:
+        budget = self.device.gpu_budget_bytes
+        if budget is None:
+            return None
+        if self.exceeds_max_alloc:
+            return False
+        return self.gpu_working_set <= budget
+
+    @property
+    def fits_host(self) -> Optional[bool]:
+        if self.device.host_available_bytes is None:
+            return None
+        return self.host_peak_bytes <= self.device.host_available_bytes
+
+    def describe_shape(self) -> str:
+        """One line naming the deskewed size, always worth printing even when it fits."""
+        z, y, x = self.output_zyx
+        return (
+            f"Deskewed volume is {z} x {y} x {x} (Z x Y x X), "
+            f"{_fmt_bytes(self.gpu_output_bytes)} as float32 on the GPU and "
+            f"{_fmt_bytes(self.voxels * self.output_itemsize)} once saved"
+        )
+
+    def summary_line(self) -> str:
+        """A one-line version of `warnings()`, for a GUI panel where the full text is
+        far too long to read. Says what is wrong and how big, and leaves the reasoning
+        and remedies to the logged messages."""
+        z, y, x = self.output_zyx
+        size = f"Whole deskewed image: {z} x {y} x {x}, {_fmt_bytes(self.gpu_output_bytes)} on the GPU"
+        # Cropping is the one fix reachable from here - it is the next tab along - and it
+        # helps in all three cases, since each ROI is deskewed and pulled back on its own.
+        may_fail = "Processing may fail; try cropping, or see terminal."
+        if self.exceeds_max_alloc:
+            return (f"{size} - larger than what this GPU can handle at once "
+                    f"({_fmt_bytes(self.device.gpu_max_alloc_bytes)}). {may_fail}")
+        if self.fits_gpu is False:
+            return (f"{size} - needs {_fmt_bytes(self.gpu_working_set)} of the "
+                    f"{_fmt_bytes(self.device.gpu_budget_bytes)} free. {may_fail}")
+        if self.fits_host is False:
+            return (f"{size} - needs {_fmt_bytes(self.host_peak_bytes)} of RAM, "
+                    f"{_fmt_bytes(self.device.host_available_bytes)} free. {may_fail}")
+        return f"{size}, {_fmt_bytes(self.voxels * self.output_itemsize)} once saved"
+
+    def warnings(self) -> List[str]:
+        """Reasons this deskew is expected to fail or thrash, most severe first.
+        Empty when it fits, or when the device could not be queried.
+
+        Each message names the deskewed size, because they are logged individually and
+        a bare "not enough memory" line tells the user nothing they can act on.
+        """
+        avoid = ("Cropping to a region of interest avoids this, since each ROI is "
+                 "deskewed on its own")
+        messages: List[str] = []
+        if self.exceeds_max_alloc:
+            messages.append(
+                f"{self.describe_shape()}. This GPU can only handle "
+                f"{_fmt_bytes(self.device.gpu_max_alloc_bytes)} at once, so deskewing the "
+                f"whole volume is likely to fail. {avoid}; otherwise use a GPU with more memory."
+            )
+        elif self.fits_gpu is False:
+            messages.append(
+                f"{self.describe_shape()}. With the input image that needs about "
+                f"{_fmt_bytes(self.gpu_working_set)} of GPU memory, but only "
+                f"{_fmt_bytes(self.device.gpu_budget_bytes)} is free. "
+                f"{avoid}; otherwise use a GPU with more memory."
+            )
+        if self.fits_host is False:
+            messages.append(
+                f"{self.describe_shape()}. Holding that result in RAM needs about "
+                f"{_fmt_bytes(self.host_peak_bytes)}, but only "
+                f"{_fmt_bytes(self.device.host_available_bytes)} is available. Processing may "
+                "swap heavily or be killed by the operating system."
+            )
+        return messages
+
+    def format_report(self) -> str:
+        """Return a short, human-readable estimate for a log/console."""
+        lines = [
+            f"Deskew estimate (no cropping): {self.input_zyx} -> {self.output_zyx}",
+            f"  Deskewed image: {_fmt_bytes(self.gpu_output_bytes)}, of the {_fmt_bytes(self.device.gpu_max_alloc_bytes)} this GPU can handle at once",
+            f"  GPU memory    : needs {_fmt_bytes(self.gpu_working_set)} of {_fmt_bytes(self.device.gpu_budget_bytes)} -> fits: {self.fits_gpu}",
+            f"  Host RAM      : needs {_fmt_bytes(self.host_peak_bytes)} of {_fmt_bytes(self.device.host_available_bytes)} -> fits: {self.fits_host}",
+        ]
+        lines.extend(f"  WARNING: {message}" for message in self.warnings())
+        return "\n".join(lines)
+
+
+@dataclass
 class MemoryEstimate:
     """Summary of a memory estimate across all ROIs."""
 
@@ -77,6 +280,9 @@ class MemoryEstimate:
     gpu_max_alloc_bytes: Optional[int]
     gpu_reserve_bytes: int
     host_available_bytes: Optional[int]
+    # Set instead of `rois` when cropping is disabled: there are no ROIs to size,
+    # but the whole-volume deskew still has to fit.
+    deskew_volume: Optional[DeskewVolumeEstimate] = None
 
     @property
     def worker_peak_bytes(self) -> int:
@@ -157,25 +363,21 @@ class MemoryEstimate:
 
     def format_report(self) -> str:
         """Return a short, human-readable memory estimate for a log/console."""
-        def fmt_bytes(n: Optional[int]) -> str:
-            if n is None:
-                return "unknown"
-            for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-                if abs(n) < 1024:
-                    return f"{n:.1f} {unit}"
-                n /= 1024
-            return f"{n:.1f} PiB"
+        if not self.rois and self.deskew_volume is not None:
+            # No cropping: the per-ROI/worker summary would be all zeroes and would
+            # read as "nothing to worry about" for exactly the volumes that fail.
+            return self.deskew_volume.format_report()
 
         lines = [
             f"Memory estimate: {len(self.rois)} ROI(s), {self.n_workers} worker(s) "
             f"(recommended: {self.recommended_workers})",
-            f"  VRAM (GPU)  : needs {fmt_bytes(self.total_gpu_bytes)} of {fmt_bytes(self.gpu_budget_bytes)} -> fits: {self.fits_gpu}",
-            f"  RAM (host)  : needs {fmt_bytes(self.total_host_bytes)} of {fmt_bytes(self.host_available_bytes)} -> fits: {self.fits_host}",
+            f"  VRAM (GPU)  : needs {_fmt_bytes(self.total_gpu_bytes)} of {_fmt_bytes(self.gpu_budget_bytes)} -> fits: {self.fits_gpu}",
+            f"  RAM (host)  : needs {_fmt_bytes(self.total_host_bytes)} of {_fmt_bytes(self.host_available_bytes)} -> fits: {self.fits_host}",
         ]
         if self.per_buffer_violators:
             lines.append(
                 f"  ERROR: {len(self.per_buffer_violators)} ROI(s) exceed the GPU's max single "
-                f"allocation ({fmt_bytes(self.gpu_max_alloc_bytes)}); no worker count can fix this."
+                f"allocation ({_fmt_bytes(self.gpu_max_alloc_bytes)}); no worker count can fix this."
             )
         return "\n".join(lines)
 
@@ -406,9 +608,12 @@ def estimate_roi(
     """
     input_bbox, intermediate, _output_bbox = get_roi_bboxes(lattice, roi_index, context=context)
     host_itemsize = _input_dtype_itemsize(lattice)
-    host_input_bytes = int(np.prod(input_bbox)) * host_itemsize
-    gpu_input_bytes = int(np.prod(input_bbox)) * GPU_DTYPE_ITEMSIZE
-    gpu_intermediate_bytes = int(np.prod(intermediate)) * GPU_DTYPE_ITEMSIZE
+    # math.prod, not np.prod: numpy's default integer is 32-bit on Windows, so a
+    # volume past 2**31 voxels - exactly the size that motivates this estimate -
+    # silently overflows to a negative byte count.
+    host_input_bytes = math.prod(input_bbox) * host_itemsize
+    gpu_input_bytes = math.prod(input_bbox) * GPU_DTYPE_ITEMSIZE
+    gpu_intermediate_bytes = math.prod(intermediate) * GPU_DTYPE_ITEMSIZE
     return RoiEstimate(
         roi_index=roi_index,
         input_bbox_zyx=input_bbox,
@@ -420,11 +625,216 @@ def estimate_roi(
     )
 
 
+def estimate_deskew_shapes(
+    input_shape_zyx: Tuple[int, int, int],
+    output_shape_zyx: Tuple[int, int, int],
+    input_dtype: Any,
+    deconvolved: bool = False,
+    safety_factor: float = DEFAULT_SAFETY_FACTOR,
+) -> DeskewVolumeEstimate:
+    """
+    Build a whole-volume estimate from shapes alone, querying the device for its limits.
+
+    Kept separate from `estimate_deskew_volume` so it can be called from the
+    `LatticeData` root validator, which has a dict of values rather than a model.
+    """
+    from lls_core.writers import resolve_output_dtype
+
+    input_itemsize = int(np.dtype(input_dtype).itemsize)
+    if deconvolved:
+        # Deconvolved output is kept as float32 rather than cast back to the input dtype.
+        output_itemsize = GPU_DTYPE_ITEMSIZE
+    else:
+        try:
+            output_itemsize = int(resolve_output_dtype(input_dtype).itemsize)
+        except Exception:
+            output_itemsize = input_itemsize
+
+    return DeskewVolumeEstimate(
+        input_zyx=tuple(int(s) for s in input_shape_zyx),  # type: ignore[arg-type]
+        output_zyx=tuple(int(s) for s in output_shape_zyx),  # type: ignore[arg-type]
+        input_itemsize=input_itemsize,
+        output_itemsize=output_itemsize,
+        safety_factor=safety_factor,
+        device=_query_device_limits(),
+    )
+
+
+def estimate_deskew_volume(
+    deskew: "DeskewParams",
+    safety_factor: float = DEFAULT_SAFETY_FACTOR,
+) -> DeskewVolumeEstimate:
+    """
+    Estimate the memory needed to deskew one whole 3D volume (the no-crop path).
+
+    Takes a `DeskewParams` rather than a full `LatticeData` so the GUI can size the
+    deskew from the Deskew tab alone, before any output settings exist.
+
+    The deskewed shape is read from the already-derived `deskew_vol_shape` rather
+    than recomputed, so this reports the buffer the pipeline will actually allocate
+    for either geometry (standard deskew or shear-only).
+    """
+    return estimate_deskew_shapes(
+        input_shape_zyx=deskew.input_image.shape[-3:],
+        output_shape_zyx=deskew.derived.deskew_vol_shape[-3:],
+        input_dtype=deskew.input_image.dtype,
+        # `deconv_enabled` only exists on LatticeData; a bare DeskewParams never deconvolves.
+        deconvolved=bool(getattr(deskew, "deconv_enabled", False)),
+        safety_factor=safety_factor,
+    )
+
+
+# Deskewed shapes already warned about. Model construction repeats for every sublattice
+# and every ROI worker, all with the same geometry, so without this the same warning
+# would be printed once per timepoint. Keyed on the shape rather than the message text:
+# the host-RAM message quotes currently-available RAM, which drifts between timepoints
+# and would defeat the dedupe exactly when the log is longest.
+_warned_shapes: set = set()
+
+
+def reset_warning_history() -> None:
+    """Forget which sizes have been warned about, so they are reported again. For tests."""
+    _warned_shapes.clear()
+
+
+def warn_once(estimate: DeskewVolumeEstimate) -> List[str]:
+    """Log this estimate's warnings in full, at most once per deskewed shape. Returns
+    the messages logged, empty if this shape has already been reported."""
+    key = tuple(estimate.output_zyx)
+    if key in _warned_shapes:
+        return []
+    _warned_shapes.add(key)
+    messages = estimate.warnings()
+    for message in messages:
+        logger.warning(message)
+    return messages
+
+
+def warn_if_deskew_may_not_fit(
+    input_shape_zyx: Tuple[int, int, int],
+    output_shape_zyx: Tuple[int, int, int],
+    input_dtype: Any,
+    deconvolved: bool = False,
+    safety_factor: float = DEFAULT_SAFETY_FACTOR,
+) -> List[str]:
+    """
+    Warn, at most once per deskewed shape, when a deskew of this size is unlikely to
+    fit on the GPU. Returns the messages logged.
+
+    Advisory only: never raises and never blocks, because the estimate is a prediction,
+    the device query can be wrong or unavailable, and a user who knows their hardware
+    should still be able to try.
+    """
+    if tuple(int(s) for s in output_shape_zyx) in _warned_shapes:
+        return []
+    try:
+        estimate = estimate_deskew_shapes(
+            input_shape_zyx, output_shape_zyx, input_dtype,
+            deconvolved=deconvolved, safety_factor=safety_factor,
+        )
+    except Exception:
+        logger.debug("Could not estimate deskew memory usage", exc_info=True)
+        return []
+    return warn_once(estimate)
+
+
+# -- Translating opaque OpenCL failures --------------------------------------
+
+# Substrings pyopencl puts in the message when an allocation or transfer runs out of
+# room. They arrive as bare RuntimeErrors naming an API call ("clEnqueueWriteBuffer
+# failed: OUT_OF_RESOURCES") with nothing about image size, which is what makes the
+# real cause so hard to guess.
+_OPENCL_MEMORY_MARKERS: Tuple[str, ...] = (
+    "OUT_OF_RESOURCES",
+    "OUT_OF_HOST_MEMORY",
+    "MEM_OBJECT_ALLOCATION_FAILURE",
+    "INVALID_BUFFER_SIZE",
+    "INVALID_IMAGE_SIZE",
+)
+
+
+class DeskewMemoryError(RuntimeError):
+    """A deskew failed because the image did not fit in GPU or host memory.
+
+    Raised in place of the original OpenCL error, which it chains as `__cause__`,
+    so the traceback still shows the underlying call that failed.
+    """
+
+
+def is_memory_error(exc: BaseException) -> bool:
+    """Whether an exception is a GPU/host out-of-memory failure in disguise.
+
+    pyopencl's own `MemoryError` does not inherit the builtin, so OpenCL failures are
+    matched on the status name in the message; the builtin still catches host-side
+    allocation failures from numpy.
+    """
+    if isinstance(exc, (MemoryError, DeskewMemoryError)):
+        return True
+    text = f"{type(exc).__name__}: {exc}".upper()
+    return any(marker in text for marker in _OPENCL_MEMORY_MARKERS)
+
+
+def _failed_buffer_detail(lattice: "LatticeData", roi_index: Optional[int]) -> List[str]:
+    """Describe what just failed: the whole deskewed volume, or one ROI's deskewed
+    subvolume when cropping. Quoting the whole-volume size for a failed ROI would name
+    an image that was never actually created."""
+    device = _query_device_limits()
+    if roi_index is None:
+        estimate = estimate_deskew_volume(lattice)
+        shape, needed = estimate.output_zyx, estimate.gpu_working_set
+        what = "The deskewed volume"
+    else:
+        roi = estimate_roi(lattice, roi_index)
+        shape, needed = roi.intermediate_zyx, roi.gpu_working_set
+        what = f"Deskewed ROI {roi_index}"
+    z, y, x = shape
+    return [
+        f"  {what} is {z} x {y} x {x} (Z x Y x X) and needs about "
+        f"{_fmt_bytes(needed)} of GPU memory.",
+        f"  This GPU has {_fmt_bytes(device.gpu_global_bytes)} and can only handle "
+        f"{_fmt_bytes(device.gpu_max_alloc_bytes)} at once.",
+    ]
+
+
+@contextmanager
+def memory_errors_explained(
+    lattice: Optional["LatticeData"] = None,
+    operation: str = "Deskewing",
+    roi_index: Optional[int] = None,
+) -> Generator[None, None, None]:
+    """
+    Re-raise out-of-memory failures from the wrapped deskew as a `DeskewMemoryError`
+    naming the size of the buffer that failed, and let every other exception through
+    untouched.
+
+    The size is only computed once a failure has happened, so this costs nothing on the
+    successful path.
+    """
+    try:
+        yield
+    except Exception as exc:
+        if not is_memory_error(exc):
+            raise
+        lines = [f"{operation} ran out of GPU or host memory."]
+        if lattice is not None:
+            try:
+                lines.extend(_failed_buffer_detail(lattice, roi_index))
+            except Exception:
+                logger.debug("Could not size the image for the memory error report", exc_info=True)
+        lines.append(
+            "  Crop to a smaller region of interest, or use a GPU with more memory."
+            if roi_index is not None else
+            "  Crop to a region of interest, or use a GPU with more memory."
+        )
+        lines.append(f"  Underlying error: {exc}")
+        raise DeskewMemoryError("\n".join(lines)) from exc
+
+
 def estimate_pipeline(
     lattice: "LatticeData",
     n_workers: int,
     safety_factor: float = DEFAULT_SAFETY_FACTOR,
-    gpu_reserve_bytes: int = 512 * 1024 * 1024,
+    gpu_reserve_bytes: int = DEFAULT_GPU_RESERVE_BYTES,
 ) -> MemoryEstimate:
     """
     Build a complete memory estimate for the configured pipeline.
@@ -441,6 +851,7 @@ def estimate_pipeline(
             gpu_max_alloc_bytes=get_max_allocation_size(),
             gpu_reserve_bytes=gpu_reserve_bytes,
             host_available_bytes=get_host_available_bytes(),
+            deskew_volume=estimate_deskew_volume(lattice, safety_factor=safety_factor),
         )
     # Compute the ROI-independent context (raw shape + reverse affine) once, not per ROI.
     context = _roi_context(lattice)

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -5,6 +5,7 @@ from dask.array.core import Array as DaskArray
 
 from typing_extensions import Any, Iterable, Optional, TYPE_CHECKING, Type
 from lls_core.deconvolution import pycuda_decon, skimage_decon, DeconvolutionChoice
+from lls_core.estimate import DEFAULT_SAFETY_FACTOR, memory_errors_explained, warn_if_deskew_may_not_fit
 from lls_core.llsz_core import crop_volume_deskew
 from lls_core.models.crop import CropParams
 from lls_core.models.deconvolution import DeconvolutionParams
@@ -140,6 +141,36 @@ class LatticeData(OutputParams, DeskewParams):
 
         # Use the Deskew version of this validator, to do the actual image loading
         return super().read_image(values)
+
+    @root_validator(skip_on_failure=True)
+    def warn_deskew_size(cls, values: dict) -> dict:
+        """
+        Report the deskewed volume size at construction, and warn if it looks too large
+        for this GPU.
+
+        Deskewing shears the volume, so the output is substantially larger than the input
+        along one axis: an image that loaded fine can still produce a buffer the device
+        cannot allocate, and the resulting OpenCL error names no dimensions. Warning here
+        means the user is told when they build the model, not partway through a long run.
+
+        Skipped for the two paths that never allocate the whole deskewed volume, where the
+        warning would be a false alarm: cropping deskews each ROI's bounding box, and MIP
+        output projects straight from the raw data.
+        """
+        if values.get("crop") is not None or values.get("save_mip"):
+            return values
+        data = values.get("input_image")
+        derived = values.get("derived")
+        if data is None or derived is None or derived.deskew_vol_shape is None:
+            return values
+        warn_if_deskew_may_not_fit(
+            input_shape_zyx=data.shape[-3:],
+            output_shape_zyx=derived.deskew_vol_shape[-3:],
+            input_dtype=data.dtype,
+            deconvolved=values.get("deconvolution") is not None,
+            safety_factor=values.get("memory_safety_factor", DEFAULT_SAFETY_FACTOR),
+        )
+        return values
 
     @validator("input_image", pre=True, always=True)
     def incomplete_final_frame(cls, v: DataArray) -> Any:
@@ -502,8 +533,8 @@ class LatticeData(OutputParams, DeskewParams):
                     decon_processing=self.deconvolution.decon_processing
                 )
 
-            yield slice.copy(update={
-                "data": self._restore_input_dtype(crop_volume_deskew(
+            with memory_errors_explained(self, f"Deskewing ROI {roi_index}", roi_index=roi_index):
+                cropped = self._restore_input_dtype(crop_volume_deskew(
                     original_volume=slice.data,
                     deconvolution=self.deconv_enabled,
                     get_deskew_and_decon=False,
@@ -520,10 +551,9 @@ class LatticeData(OutputParams, DeskewParams):
                     skew_dir=self.skew_dir,
                     coverslip_rotation=self.coverslip_rotation,
                     **deconv_args
-                )),
-                "roi_index": roi_index
-            })
-            
+                ))
+            yield slice.copy(update={"data": cropped, "roi_index": roi_index})
+
     def _process_non_crop(self) -> Iterable[ImageSlice]:
         """
         Yields processed image slices without cropping
@@ -556,8 +586,10 @@ class LatticeData(OutputParams, DeskewParams):
                         boundary='nearest'
                     )
 
-            yield slice.copy_with_data(
-                self._restore_input_dtype(cle.pull_zyx(self.deskew_func(
+            # The deskewed buffer and the pull back to the host are where an oversized
+            # volume actually fails, with an OpenCL error that names no dimensions.
+            with memory_errors_explained(self, "Deskewing this image"):
+                deskewed = self._restore_input_dtype(cle.pull_zyx(self.deskew_func(
                     input_image=data,
                     angle_in_degrees=self.angle,
                     linear_interpolation=True,
@@ -565,7 +597,7 @@ class LatticeData(OutputParams, DeskewParams):
                     voxel_size_y=self.dy,
                     voxel_size_z=self.dz
                 )))
-            )
+            yield slice.copy_with_data(deskewed)
 
     def process_workflow(self) -> WorkflowSlices:
         """

--- a/core/tests/test_memory_warning.py
+++ b/core/tests/test_memory_warning.py
@@ -1,0 +1,301 @@
+"""
+Tests for the deskew memory warning: predicting that a deskewed volume will not fit
+on the GPU, and translating the opaque OpenCL failure when it does not.
+
+The warning is advisory by design - these tests pin that it never blocks processing.
+"""
+from __future__ import annotations
+
+import logging
+import tempfile
+
+import numpy as np
+import pytest
+from xarray import DataArray
+
+from lls_core.estimate import (
+    DeskewMemoryError,
+    DeskewVolumeEstimate,
+    DeviceLimits,
+    estimate_pipeline,
+    is_memory_error,
+    memory_errors_explained,
+    reset_warning_history,
+    warn_if_deskew_may_not_fit,
+)
+from lls_core.models.crop import CropParams
+from lls_core.models.lattice_data import LatticeData
+
+GIB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def _forget_warnings():
+    """The warning dedupe is process-global, so clear it around every test."""
+    reset_warning_history()
+    yield
+    reset_warning_history()
+
+
+@pytest.fixture
+def tiny_gpu(monkeypatch):
+    """A device too small for anything, so the warning path is exercised."""
+    from lls_core import estimate as est_mod
+    monkeypatch.setattr(est_mod, "get_max_allocation_size", lambda: 100 * 1024)
+    monkeypatch.setattr(est_mod, "get_global_mem_size", lambda: 8 * GIB)
+    monkeypatch.setattr(est_mod, "get_host_available_bytes", lambda: 8 * GIB)
+
+
+def _estimate(output_zyx, input_zyx=(100, 200, 300), max_alloc=4 * GIB,
+              global_mem=8 * GIB, host=16 * GIB) -> DeskewVolumeEstimate:
+    return DeskewVolumeEstimate(
+        input_zyx=input_zyx,
+        output_zyx=output_zyx,
+        input_itemsize=2,
+        output_itemsize=2,
+        safety_factor=1.5,
+        device=DeviceLimits(
+            gpu_global_bytes=global_mem,
+            gpu_max_alloc_bytes=max_alloc,
+            gpu_reserve_bytes=512 * 1024 * 1024,
+            host_available_bytes=host,
+        ),
+    )
+
+
+def _make_lattice(raw: np.ndarray, tmpdir: str, **kwargs) -> LatticeData:
+    return LatticeData(
+        input_image=DataArray(raw, dims=["Z", "Y", "X"]),
+        physical_pixel_sizes=(1, 1, 1),
+        angle=30,
+        skew="Y",
+        save_name="test",
+        save_dir=tmpdir,
+        save_type="tiff",
+        **kwargs,
+    )
+
+
+# --- the estimate -----------------------------------------------------------
+
+def test_large_volume_does_not_overflow_to_negative_bytes():
+    """numpy's default integer is 32-bit on Windows, so np.prod would wrap past
+    2**31 voxels - exactly the size range this estimate exists to describe."""
+    est = _estimate(input_zyx=(294, 2304, 1024), output_zyx=(294, 2304, 5184))
+    assert est.voxels > 2 ** 31
+    assert est.gpu_output_bytes > 0
+    assert est.gpu_working_set > 0
+    assert est.host_peak_bytes > 0
+
+
+def test_no_warning_when_it_fits():
+    est = _estimate(output_zyx=(10, 10, 10), input_zyx=(10, 10, 10))
+    assert est.fits_gpu is True
+    assert est.warnings() == []
+
+
+def test_per_allocation_cap_fails_even_with_free_vram():
+    """The cap is per buffer: plenty of total VRAM does not make an oversized
+    single allocation legal."""
+    est = _estimate(output_zyx=(294, 2304, 5184), max_alloc=2 * GIB, global_mem=64 * GIB)
+    assert est.exceeds_max_alloc is True
+    warning = est.warnings()[0]
+    assert "294 x 2304 x 5184" in warning       # the size the user needs to know
+    assert "can only handle" in warning
+
+
+def test_unknown_device_limits_produce_no_warning():
+    """A device we could not query is not evidence of a problem."""
+    est = _estimate(output_zyx=(294, 2304, 5184), max_alloc=None, global_mem=None, host=None)
+    assert est.fits_gpu is None
+    assert est.warnings() == []
+
+
+def test_host_shortfall_is_reported_with_the_size():
+    est = _estimate(output_zyx=(200, 1024, 1024), max_alloc=64 * GIB,
+                    global_mem=64 * GIB, host=1 * GIB)
+    assert est.fits_gpu is True
+    warning = est.warnings()[0]
+    assert "200 x 1024 x 1024" in warning
+    assert "operating system" in warning
+
+
+def test_no_crop_report_describes_the_volume_instead_of_zero_rois():
+    """Without cropping there are no ROIs to size, but the whole-volume deskew
+    still has to fit; an all-zeroes worker summary would read as 'nothing to
+    worry about' for exactly the images that fail."""
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = _make_lattice(raw, tmpdir)
+        est = estimate_pipeline(lattice, n_workers=1)
+    assert est.rois == []
+    assert est.deskew_volume is not None
+    assert est.deskew_volume.output_zyx == tuple(lattice.derived.deskew_vol_shape)
+    assert "Deskew estimate (no cropping)" in est.format_report()
+
+
+# --- warning emission -------------------------------------------------------
+
+def test_warns_at_model_construction(tiny_gpu, caplog):
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    with caplog.at_level(logging.WARNING, logger="lls_core.estimate"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _make_lattice(raw, tmpdir)
+    assert any("can only handle" in r.message for r in caplog.records)
+
+
+def test_repeated_construction_warns_once_even_as_free_ram_drifts(monkeypatch, caplog):
+    """Model construction repeats per sublattice and per ROI worker with the same
+    geometry, so the same size must not be reported once per timepoint. The dedupe is
+    keyed on the deskewed shape, not the message text, because the host-RAM message
+    quotes currently-free RAM - which drifts precisely while a big run is allocating."""
+    from lls_core import estimate as est_mod
+    monkeypatch.setattr(est_mod, "get_max_allocation_size", lambda: 100 * 1024)
+    monkeypatch.setattr(est_mod, "get_global_mem_size", lambda: 8 * GIB)
+    # Below the ~1.0 MiB this deskew needs on the host, and drifting, so the host
+    # message differs every time while the geometry does not.
+    free = iter([900_000, 890_000, 800_000, 500_000])
+    monkeypatch.setattr(est_mod, "get_host_available_bytes", lambda: next(free))
+
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    with caplog.at_level(logging.WARNING, logger="lls_core.estimate"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for _ in range(4):
+                _make_lattice(raw, tmpdir)
+    # One GPU warning and one host warning, emitted once between them - not once per build.
+    assert len(caplog.records) == 2
+
+
+def test_safety_factor_is_honoured(monkeypatch, caplog):
+    """`memory_safety_factor` is documented as the knob to turn up after OOM crashes,
+    so the warning must agree with `lls estimate` about whether a run fits."""
+    from lls_core import estimate as est_mod
+    # A GPU budget of 1 MB: above the ~665 KB this deskew needs at a safety factor of
+    # 1.0, below the ~5.3 MB it needs at 8.0.
+    monkeypatch.setattr(est_mod, "get_max_allocation_size", lambda: 64 * GIB)
+    monkeypatch.setattr(est_mod, "get_global_mem_size", lambda: 1_000_000 + 512 * 1024 * 1024)
+    monkeypatch.setattr(est_mod, "get_host_available_bytes", lambda: 8 * GIB)
+
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with caplog.at_level(logging.WARNING, logger="lls_core.estimate"):
+            _make_lattice(raw, tmpdir, memory_safety_factor=1.0)
+        lenient = len(caplog.records)
+        caplog.clear()
+        reset_warning_history()
+        with caplog.at_level(logging.WARNING, logger="lls_core.estimate"):
+            _make_lattice(raw, tmpdir, memory_safety_factor=8.0)
+        strict = len(caplog.records)
+    assert lenient == 0 and strict == 1
+
+
+@pytest.mark.parametrize("kwargs, why", [
+    ({"crop": CropParams(roi_list=[[[0, 0], [0, 40], [40, 40], [40, 0]]], z_range=(0, 20))},
+     "cropping deskews each ROI's bounding box, never the whole volume"),
+    ({"save_mip": True},
+     "MIP output projects straight from the raw data"),
+])
+def test_no_warning_for_paths_that_never_allocate_the_volume(tiny_gpu, caplog, kwargs, why):
+    """Warning about a buffer that is never allocated would send the user chasing a
+    problem they do not have - and, for cropping, tell them to do what they already are."""
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    with caplog.at_level(logging.WARNING, logger="lls_core.estimate"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _make_lattice(raw, tmpdir, **kwargs)
+    assert [r for r in caplog.records if "can only handle" in r.message] == [], why
+
+
+def test_warning_helper_swallows_a_broken_estimate(monkeypatch):
+    """A failed estimate must not stop a job that might well have succeeded."""
+    from lls_core import estimate as est_mod
+
+    def explode():
+        raise RuntimeError("no device")
+
+    monkeypatch.setattr(est_mod, "get_max_allocation_size", explode)
+    assert warn_if_deskew_may_not_fit((1, 2, 3), (1, 2, 6), np.dtype("uint16")) == []
+
+
+def test_oversized_image_is_warned_about_but_still_processed(tiny_gpu, caplog):
+    """The estimate is a prediction, not a gate: a user who knows their hardware
+    must still be able to try."""
+    raw = np.random.randint(0, 100, (30, 50, 50), dtype=np.uint16)
+    with caplog.at_level(logging.WARNING, logger="lls_core.estimate"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = list(_make_lattice(raw, tmpdir).process().slices)
+    assert any("can only handle" in r.message for r in caplog.records)
+    assert len(results) == 1
+
+
+# --- translating the OpenCL failure -----------------------------------------
+
+@pytest.mark.parametrize("exc, recognised", [
+    (RuntimeError("clEnqueueReadBuffer failed: OUT_OF_RESOURCES"), True),
+    (RuntimeError("clEnqueueWriteBuffer failed: OUT_OF_RESOURCES"), True),
+    (RuntimeError("clCreateBuffer failed: MEM_OBJECT_ALLOCATION_FAILURE"), True),
+    (RuntimeError("clCreateBuffer failed: INVALID_BUFFER_SIZE"), True),
+    (MemoryError(), True),
+    (RuntimeError("clBuildProgram failed: BUILD_PROGRAM_FAILURE"), False),
+    (ValueError("angle must be positive"), False),
+])
+def test_only_memory_failures_are_recognised(exc, recognised):
+    assert is_memory_error(exc) is recognised
+
+
+def test_context_manager_passes_other_errors_through_unchanged():
+    with pytest.raises(ValueError, match="unrelated"):
+        with memory_errors_explained(None, "Deskewing"):
+            raise ValueError("unrelated")
+
+
+def test_processing_translates_the_opencl_error(monkeypatch):
+    """End to end: the error a user actually sees names the image size instead of
+    only an OpenCL status code."""
+    import pyclesperanto_prototype as cle
+
+    def out_of_resources(*args, **kwargs):
+        raise RuntimeError("clEnqueueReadBuffer failed: OUT_OF_RESOURCES")
+
+    monkeypatch.setattr(cle, "pull_zyx", out_of_resources)
+
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = _make_lattice(raw, tmpdir)
+        with pytest.raises(DeskewMemoryError) as excinfo:
+            list(lattice.process().slices)
+
+    message = str(excinfo.value)
+    assert "ran out of GPU or host memory" in message
+    # The deskewed size, which the raw OpenCL error never mentions
+    z, y, x = lattice.derived.deskew_vol_shape
+    assert f"{z} x {y} x {x}" in message
+    # The original error survives, both in the text and as the chained cause
+    assert "clEnqueueReadBuffer failed: OUT_OF_RESOURCES" in message
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+
+def test_crop_failure_reports_the_roi_size_not_the_whole_volume(monkeypatch):
+    """A failed ROI must be described by its own deskewed subvolume. Quoting the
+    whole-volume size would name a buffer that was never allocated, and telling a
+    user who is already cropping to 'crop to a region of interest' is no help."""
+    import lls_core.models.lattice_data as ld
+    from lls_core.estimate import estimate_roi
+
+    def out_of_resources(*args, **kwargs):
+        raise RuntimeError("clEnqueueWriteBuffer failed: OUT_OF_RESOURCES")
+
+    monkeypatch.setattr(ld, "crop_volume_deskew", out_of_resources)
+
+    raw = np.zeros((30, 50, 50), dtype=np.uint16)
+    rois = [[[0, 0], [0, 30], [30, 30], [30, 0]]]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lattice = _make_lattice(raw, tmpdir, crop=CropParams(roi_list=rois, z_range=(0, 20)))
+        roi_shape = estimate_roi(lattice, 0).intermediate_zyx
+        with pytest.raises(DeskewMemoryError) as excinfo:
+            list(lattice.process().slices)
+
+    message = str(excinfo.value)
+    assert "ROI 0" in message
+    assert "{} x {} x {}".format(*roi_shape) in message
+    whole_volume = "{} x {} x {}".format(*lattice.derived.deskew_vol_shape)
+    assert whole_volume not in message, "must not quote a buffer that is never allocated"

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -184,6 +184,27 @@ class NapariFieldGroup(MagicTemplate):
             errors.setStyleSheet("color: red;")
             # errors.setWordWrap(True)
 
+        # Only the Deskew tab has this readout, and it is the one label long enough to
+        # wrap. A wrapping QLabel defaults to a Fixed policy, so it picks its own narrow
+        # width and stacks the text into a block instead of running the panel's width;
+        # `Ignored` lets the layout give it the full row instead.
+        #
+        # The height must be capped. A wrapping label that can grow freely reports an
+        # ever-larger minimum height as the dock narrows, and because that minimum
+        # propagates up through the tab stack and splitters it becomes a floor on the
+        # whole napari window - the user can no longer shrink it. Qt's heightForWidth is
+        # the "correct" answer here but makes it worse for the same reason, since
+        # QStackedLayout does not handle it. Three lines is enough for the longest
+        # message at the panel's minimum width, so nothing is clipped in practice.
+        estimate = getattr(self, "memory_estimate", None)
+        if estimate is not None and isinstance(estimate.native, QLabel):
+            from qtpy.QtWidgets import QSizePolicy
+            native = estimate.native
+            native.setWordWrap(True)
+            native.setMinimumWidth(1)
+            native.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Minimum)
+            native.setMaximumHeight(native.fontMetrics().lineSpacing() * 3)
+
         from qtpy.QtCore import Qt
         self._widget._layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
@@ -311,6 +332,12 @@ class DeskewFields(NapariFieldGroup):
         label="Quick Deskew",
         tooltip = "View the deskewed image. This does NOT generate a new image, but instead transforms\nthe current image in the viewer. Use `Preview` to generate a new image.")
     errors = field(Label).with_options(label="Errors")
+    # Live readout of how large the deskewed volume will be. Deskewing grows the image
+    # along the shear axis, so an input that loads fine can produce a buffer the GPU
+    # cannot allocate; without this the user only finds out when a long run dies on an
+    # OpenCL error that names no dimensions. Separate from `errors` because an oversized
+    # image is not a validation failure - the settings are legal, the hardware is small.
+    memory_estimate = field(Label).with_options(label="Deskewed Size", visible=False)
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -550,6 +577,42 @@ class DeskewFields(NapariFieldGroup):
             invert_scan_direction=kwargs["invert_scan_direction"],
             coverslip_rotation=kwargs["coverslip_rotation"],
         )
+
+    def _validate(self):
+        super()._validate()
+        self._update_memory_estimate()
+
+    def _update_memory_estimate(self) -> None:
+        """
+        Refresh the deskewed-size readout for the current settings.
+
+        Show a single line in plugin with rest of explanation in the terminal,
+        once per deskewed shape.
+
+        Runs on every field change, so it does only shape arithmetic and a cached device
+        query - no pixels. Hidden while the settings are invalid, which is common
+        mid-edit and is `errors`' job to report rather than this one's.
+        """
+        from lls_core.estimate import estimate_deskew_volume, warn_once
+
+        if self.errors.value:
+            self.memory_estimate.visible = False
+            return
+        try:
+            estimate = estimate_deskew_volume(self._make_model())
+            too_big = bool(estimate.warnings())
+            if too_big:
+                warn_once(estimate)
+        except Exception:
+            self.memory_estimate.visible = False
+            return
+
+        self.memory_estimate.value = estimate.summary_line()
+        self.memory_estimate.visible = True
+        from qtpy.QtWidgets import QLabel
+        native = self.memory_estimate.native
+        if isinstance(native, QLabel):
+            native.setStyleSheet("color: orange;" if too_big else "")
 
 @magicclass
 class DeconvolutionFields(NapariFieldGroup):


### PR DESCRIPTION
Improved user experience by providing explicit warnings if there are potential GPU VRAM memory issues during processing, instead of vague error messages. 

Inform users if the deskewed image may exceed available VRAM, allowing for better management of resources. Recommend cropping as an alternative. 

The codebase here can form the basis for tiling on GPU: https://github.com/BioimageAnalysisCoreWEHI/napari_lattice/pull/137