### PR TITLE
Metadata file for every output, and fix off-centre ROI placement

### DIFF
--- a/core/lls_core/estimate.py
+++ b/core/lls_core/estimate.py
@@ -488,12 +488,6 @@ def _local_cpu_cap() -> Optional[int]:
 
 # -- Per-ROI bbox math (pixel-free) ------------------------------------------
 
-class _ShapeOnly:
-    """Lightweight stand-in for a volume; only `.shape` is read by the deskew helpers."""
-    def __init__(self, shape: Tuple[int, ...]) -> None:
-        self.shape = shape
-
-
 def _roi_to_shape_array(roi: Any) -> np.ndarray:
     """Coerce a Roi/np.ndarray/list-of-points into the ndarray shape that
     `calculate_crop_bbox` expects."""
@@ -506,18 +500,18 @@ def _roi_to_shape_array(roi: Any) -> np.ndarray:
 def _roi_context(lattice: "LatticeData") -> Tuple[Tuple[int, int, int], Any, "DeskewDirection"]:
     """
     Compute the ROI-independent inputs shared by every ROI's bbox: the raw 3D shape,
-    the reverse (deskewed->raw) affine, and the skew direction. Hoisting these out of
-    the per-ROI loop avoids recomputing the affine and re-slicing for each ROI.
+    the deskew transforms, and the skew direction. Hoisting these out of the per-ROI
+    loop avoids recomputing the affine and re-slicing for each ROI.
     """
-    from lls_core.llsz_core import get_inverse_affine_transform
+    from lls_core.llsz_core import objective_crop_transforms
 
     raw_3d = lattice.get_3d_slice()
     raw_shape_zyx = tuple(int(s) for s in raw_3d.shape[-3:])
     skew_dir = lattice.skew if isinstance(lattice.skew, DeskewDirection) else DeskewDirection[str(lattice.skew)]
-    reverse_aff, _excess, _deskew = get_inverse_affine_transform(
-        _ShapeOnly(raw_shape_zyx), lattice.angle, lattice.dx, lattice.dy, lattice.dz, skew_dir,
+    transforms = objective_crop_transforms(
+        raw_shape_zyx, lattice.angle, lattice.dx, lattice.dy, lattice.dz, skew_dir,
     )
-    return raw_shape_zyx, reverse_aff, skew_dir
+    return raw_shape_zyx, transforms, skew_dir
 
 
 def get_roi_bboxes(
@@ -535,30 +529,35 @@ def get_roi_bboxes(
     `context` is the ROI-independent `_roi_context(lattice)`; it is computed here when
     omitted, but `estimate_pipeline` passes it in once to avoid per-ROI recomputation.
     """
-    from lls_core.utils import calculate_crop_bbox, get_deskewed_shape
+    from lls_core.llsz_core import objective_crop_geometry
+    from lls_core.utils import ShapeOnly, get_deskewed_shape
 
     if lattice.crop is None:
         raise ValueError("get_roi_bboxes requires a LatticeData with cropping enabled")
 
-    raw_shape_zyx, reverse_aff, skew_dir = context if context is not None else _roi_context(lattice)
+    raw_shape_zyx, transforms, skew_dir = context if context is not None else _roi_context(lattice)
 
     roi_shape = _roi_to_shape_array(lattice.crop.roi_list[roi_index])
     z_start, z_end = lattice.crop.z_range
-    crop_bounding_box, crop_vol_shape = calculate_crop_bbox(roi_shape, z_start, z_end)
-    crop_vol_shape_zyx: Tuple[int, int, int] = (
-        int(crop_vol_shape[0]),
-        int(crop_vol_shape[1]),
-        int(crop_vol_shape[2]),
-    )
 
-    # Map ROI corners back to raw-volume xyz coordinates and take the clipped extents.
-    bbox = np.asarray([reverse_aff._matrix @ v for v in crop_bounding_box])
-    mn = np.around(bbox.min(axis=0)).astype(int)
-    mx = np.around(bbox.max(axis=0)).astype(int)
-    nx, ny, nz = raw_shape_zyx[2], raw_shape_zyx[1], raw_shape_zyx[0]
-    x0, x1 = np.clip([mn[0], mx[0]], 0, nx)
-    y0, y1 = np.clip([mn[1], mx[1]], 0, ny)
-    z0, z1 = np.clip([mn[2], mx[2]], 0, nz)
+    # Same helper `crop_volume_deskew` uses, so the estimate cannot describe a
+    # differently-sized sub-block than the one actually read.
+    geometry = objective_crop_geometry(
+        raw_shape_zyx=raw_shape_zyx,
+        roi_shape=roi_shape,
+        z_start=z_start,
+        z_end=z_end,
+        angle_in_degrees=lattice.angle,
+        voxel_size_x=lattice.dx,
+        voxel_size_y=lattice.dy,
+        voxel_size_z=lattice.dz,
+        skew_dir=skew_dir,
+        transforms=transforms,
+    )
+    crop_vol_shape_zyx: Tuple[int, int, int] = geometry.crop_vol_shape
+    x0, x1 = geometry.raw_x
+    y0, y1 = geometry.raw_y
+    z0, z1 = geometry.raw_z
     input_bbox_zyx: Tuple[int, int, int] = (
         int(max(0, z1 - z0)),
         int(max(0, y1 - y0)),
@@ -570,7 +569,7 @@ def get_roi_bboxes(
     # with the input on the GPU and is usually the largest single buffer.
     if all(d > 0 for d in input_bbox_zyx):
         intermediate_shape, _ = get_deskewed_shape(
-            _ShapeOnly(input_bbox_zyx),
+            ShapeOnly(input_bbox_zyx),
             lattice.angle,
             lattice.dx,
             lattice.dy,

--- a/core/lls_core/llsz_core.py
+++ b/core/lls_core/llsz_core.py
@@ -5,14 +5,14 @@ import pyclesperanto_prototype as cle
 from dask.array.core import Array as DaskArray
 import dask.array as da
 from resource_backed_dask_array import ResourceBackedDaskArray
-from typing import Any, Optional, Union, TYPE_CHECKING, overload, Literal, Tuple
+from typing import Any, NamedTuple, Optional, Union, TYPE_CHECKING, overload, Literal, Tuple
 from typing_extensions import Unpack, TypedDict, Required
 from pyclesperanto_prototype._tier8._affine_transform_deskew_3d import (
     affine_transform_deskew_3d,
 )
 from numpy.typing import NDArray
  
-from lls_core.utils import calculate_crop_bbox
+from lls_core.utils import calculate_crop_bbox, ShapeOnly
 from lls_core import config, DeskewDirection
 from lls_core.types import ArrayLike
 from lls_core.deconvolution import pycuda_decon, skimage_decon, DeconvolutionChoice
@@ -33,6 +33,152 @@ Psf = Union[
         ResourceBackedDaskArray,
         cle._tier0._pycl.OCLArray,
 ]
+
+class ObjectiveCropGeometry(NamedTuple):
+    """
+    Where an objective-frame (`coverslip_rotation=True`) deskewed crop sits, and which
+    raw sub-block produces it. Pure geometry: no pixels are read.
+
+    `origin_zyx` is the position of the crop's voxel `(0, 0, 0)` within the FULL
+    deskewed volume, in deskewed voxels. It is **not** simply the ROI origin:
+    `crop_volume_deskew` only trims the *skew* axis to the ROI (via `crop_excess`),
+    so on the other two axes the output keeps whatever bounds the clipped raw
+    sub-block happened to deskew into. In particular the Z origin is the sub-block's
+    minimum deskewed Z, **not** `z_start` - the output is never sliced on Z.
+
+    Deriving this anywhere other than here would drift from what the crop actually
+    does; `crop_volume_deskew`, `get_roi_bboxes` and the output metadata all read it
+    from this one function.
+    """
+    #: Raw-volume slice bounds, each `(start, stop)`.
+    raw_x: Tuple[int, int]
+    raw_y: Tuple[int, int]
+    raw_z: Tuple[int, int]
+    #: Offset along the skew axis from the sub-block's deskewed origin to the ROI's.
+    crop_excess: int
+    #: Final crop shape `(z, y, x)`, i.e. the ROI extent.
+    crop_vol_shape: Tuple[int, int, int]
+    #: Crop voxel (0,0,0) in full-deskewed-volume voxels, `(z, y, x)`.
+    origin_zyx: Tuple[float, float, float]
+    #: Raw -> deskewed affine for this acquisition.
+    deskew_transform: Any
+
+
+def objective_crop_transforms(
+    raw_shape_zyx: Tuple[int, ...],
+    angle_in_degrees: float,
+    voxel_size_x: float,
+    voxel_size_y: float,
+    voxel_size_z: float,
+    skew_dir: DeskewDirection = DeskewDirection.Y,
+) -> Tuple[Any, Any]:
+    """
+    The ROI-independent `(reverse_aff, deskew_transform)` pair, hoisted so a caller
+    looping over many ROIs computes the affine once rather than per ROI.
+    """
+    reverse_aff, _excess_bounds, deskew_transform = get_inverse_affine_transform(
+        ShapeOnly(tuple(int(s) for s in raw_shape_zyx)),
+        angle_in_degrees,
+        voxel_size_x,
+        voxel_size_y,
+        voxel_size_z,
+        skew_dir,
+    )
+    return reverse_aff, deskew_transform
+
+
+def objective_crop_geometry(
+    raw_shape_zyx: Tuple[int, ...],
+    roi_shape: Union[list, NDArray],
+    z_start: int,
+    z_end: int,
+    angle_in_degrees: float,
+    voxel_size_x: float,
+    voxel_size_y: float,
+    voxel_size_z: float,
+    skew_dir: DeskewDirection = DeskewDirection.Y,
+    transforms: Optional[Tuple[Any, Any]] = None,
+) -> ObjectiveCropGeometry:
+    """
+    Resolve one ROI into the raw sub-block to read and the deskewed position of the
+    resulting crop. See `ObjectiveCropGeometry` for what `origin_zyx` means.
+
+    Pass `transforms` from `objective_crop_transforms` to avoid recomputing the affine
+    once per ROI.
+    """
+    from itertools import product
+
+    crop_bounding_box, crop_vol_shape = calculate_crop_bbox(roi_shape, z_start, z_end)
+
+    if transforms is None:
+        transforms = objective_crop_transforms(
+            raw_shape_zyx, angle_in_degrees, voxel_size_x, voxel_size_y, voxel_size_z, skew_dir
+        )
+    reverse_aff, deskew_transform = transforms
+
+    # Apply the reverse transform to get the corresponding bounding box in the raw volume
+    crop_transform_bbox = np.asarray(
+        [reverse_aff._matrix @ corner for corner in crop_bounding_box]
+    )
+
+    # Raw shape in xyz, to match the transform's coordinate order
+    orig_img_shape = tuple(int(s) for s in raw_shape_zyx)[::-1]
+
+    # Take min and max of the transformed bounding box, clipped so we never index
+    # outside the raw volume
+    min_coordinate = np.around(crop_transform_bbox.min(axis=0))
+    max_coordinate = np.around(crop_transform_bbox.max(axis=0))
+
+    x_start = int(np.clip(min_coordinate[0].astype(int), 0, orig_img_shape[0]))
+    x_end = int(np.clip(max_coordinate[0].astype(int), 0, orig_img_shape[0]))
+    y_start = int(np.clip(min_coordinate[1].astype(int), 0, orig_img_shape[1]))
+    y_end = int(np.clip(max_coordinate[1].astype(int), 0, orig_img_shape[1]))
+    z_start_vol = int(np.clip(min_coordinate[2].astype(int), 0, orig_img_shape[2]))
+    z_end_vol = int(np.clip(max_coordinate[2].astype(int), 0, orig_img_shape[2]))
+
+    # make sure z_start < z_end
+    if z_start_vol > z_end_vol:
+        z_start_vol, z_end_vol = z_end_vol, z_start_vol
+
+    # The deskewed sub-block is larger than the crop (the shear adds empty wedges), and
+    # its row/col 0 is the MINIMUM deskewed coordinate of the clipped sub-block, so
+    # crop_excess = round(ROI_origin - that_minimum). Old code assumed the ROI was
+    # centred ((deskewed_dim - crop_dim) / 2 + an out-of-bounds fudge), which only holds
+    # at scan-centre and mis-placed off-centre ROIs. This was not the case with larger
+    # datasets where ROIs were far away from scan centre. Projecting the clipped corners
+    # through the raw->deskewed transform is exact.
+    full_deskew_matrix = np.linalg.inv(reverse_aff._matrix)  # raw->deskewed, incl. translation
+    sub_corners = np.asarray([
+        [x, y, z, 1]
+        for x, y, z in product((x_start, x_end), (y_start, y_end), (z_start_vol, z_end_vol))
+    ])
+    prelim_corners = (full_deskew_matrix @ sub_corners.T).T  # deskewed xyz of sub-block corners
+    roi_origin = np.asarray(crop_bounding_box).min(axis=0)   # [x, y, z, 1]
+
+    # Deskewed position of the sub-block's own voxel (0, 0, 0)
+    prelim_origin_x = float(prelim_corners[:, 0].min())
+    prelim_origin_y = float(prelim_corners[:, 1].min())
+    prelim_origin_z = float(prelim_corners[:, 2].min())
+
+    if skew_dir == DeskewDirection.Y:
+        crop_excess = max(int(round(float(roi_origin[1]) - prelim_origin_y)), 0)
+        origin_zyx = (prelim_origin_z, prelim_origin_y + crop_excess, prelim_origin_x)
+    elif skew_dir == DeskewDirection.X:
+        crop_excess = max(int(round(float(roi_origin[0]) - prelim_origin_x)), 0)
+        origin_zyx = (prelim_origin_z, prelim_origin_y, prelim_origin_x + crop_excess)
+    else:
+        raise ValueError(f"Unknown skew direction {skew_dir!r}")
+
+    return ObjectiveCropGeometry(
+        raw_x=(x_start, x_end),
+        raw_y=(y_start, y_end),
+        raw_z=(z_start_vol, z_end_vol),
+        crop_excess=crop_excess,
+        crop_vol_shape=(int(crop_vol_shape[0]), int(crop_vol_shape[1]), int(crop_vol_shape[2])),
+        origin_zyx=origin_zyx,
+        deskew_transform=deskew_transform,
+    )
+
 
 class CommonArgs(TypedDict, total=False):
     original_volume: Required[ArrayLike]
@@ -127,17 +273,14 @@ def crop_volume_deskew(
 
     assert len(shape) == 4, print("Shape must be an array of shape 4")
 
-    crop_bounding_box, crop_vol_shape = calculate_crop_bbox(
-        shape, z_start, z_end
-    )
-
     if not coverslip_rotation:
         # OPM/SOPi: ROI corners are in the coverslip frame → map to raw via the
         # frozen coverslip inverse map (shear_only_inverse_map), not the objective affine.
         return _crop_volume_deskew_shear_only(
             original_volume=original_volume,
-            crop_bounding_box=crop_bounding_box,
-            crop_vol_shape=crop_vol_shape,
+            roi_shape=shape,
+            z_start=z_start,
+            z_end=z_end,
             angle_in_degrees=angle_in_degrees,
             voxel_size_x=voxel_size_x,
             voxel_size_y=voxel_size_y,
@@ -151,59 +294,21 @@ def crop_volume_deskew(
             get_deskew_and_decon=get_deskew_and_decon,
         )
 
-    # get reverse transform by rotating around original volume
-    (
-        reverse_aff,
-        excess_bounds,
-        deskew_transform,
-    ) = get_inverse_affine_transform(
-        original_volume,
-        angle_in_degrees,
-        voxel_size_x,
-        voxel_size_y,
-        voxel_size_z,
-        skew_dir,
+    geometry = objective_crop_geometry(
+        raw_shape_zyx=original_volume.shape,
+        roi_shape=shape,
+        z_start=z_start,
+        z_end=z_end,
+        angle_in_degrees=angle_in_degrees,
+        voxel_size_x=voxel_size_x,
+        voxel_size_y=voxel_size_y,
+        voxel_size_z=voxel_size_z,
+        skew_dir=skew_dir,
     )
-
-    # apply the transform to get corresponding bounding boxes in original volume
-    crop_transform_bbox = np.asarray(
-        list(map(lambda x: reverse_aff._matrix @ x, crop_bounding_box))
-    )
-
-    # get shape of original volume in xyz
-    orig_img_shape = original_volume.shape[::-1]
-
-    # Take min and max of the cropped bounding boxes to define min and max coordinates
-    # crop_transform_bbox is in the form xyz
-
-    min_coordinate = np.around(crop_transform_bbox.min(axis=0))
-    max_coordinate = np.around(crop_transform_bbox.max(axis=0))
-
-    # get min and max in each position
-    # clip them to avoid negative values and any values outside the bounding box of original volume
-    x_start = min_coordinate[0].astype(int)
-    x_start = np.clip(x_start, 0, orig_img_shape[0])
-    x_end = max_coordinate[0].astype(int)
-    x_end = np.clip(x_end, 0, orig_img_shape[0])
-
-    y_start = min_coordinate[1].astype(int)
-    y_start = np.clip(y_start, 0, orig_img_shape[1])
-
-    y_end = max_coordinate[1].astype(int)
-    y_end = np.clip(y_end, 0, orig_img_shape[1])
-
-    z_start_vol_prelim = min_coordinate[2].astype(int)
-    # clip to z bounds of original volume
-    z_start_vol = np.clip(z_start_vol_prelim, 0, orig_img_shape[2])
-
-    z_end_vol_prelim = max_coordinate[2].astype(int)
-    # clip to z bounds of original volume
-    z_end_vol = np.clip(z_end_vol_prelim, 0, orig_img_shape[2])
-
-    # make sure z_start < z_end
-    if z_start_vol > z_end_vol:
-        # tuple swap  #https://docs.python.org/3/reference/expressions.html#evaluation-order
-        z_start_vol, z_end_vol = z_end_vol, z_start_vol
+    x_start, x_end = geometry.raw_x
+    y_start, y_end = geometry.raw_y
+    z_start_vol, z_end_vol = geometry.raw_z
+    deskew_transform = geometry.deskew_transform
 
     # After getting the coordinates, crop from original volume and deskew only the cropped volume
 
@@ -277,37 +382,19 @@ def crop_volume_deskew(
             deskew_direction=skew_dir,
         )
 
-    # deskewed_prelim is larger than the crop (the shear adds empty wedges), and
-    # its row/col 0 is the MINIMUM deskewed coordinate of the clipped sub-block,
-    # so crop_excess = round(ROI_origin - that_minimum). Old code assumed 
-    # ROI was centred ((deskewed_dim - crop_dim) / 2 + an out-of-bounds fudge),
-    # which only holds at scan-centre and mis-placed off-centre ROIs. 
-    # This was not the case with larger datasets where ROIs were far away from scan centre,
-    # Projecting the clipped corners through the raw->deskewed transform is exact.
+    # Only the skew axis is trimmed to the ROI; see `ObjectiveCropGeometry`.
     deskewed_prelim = np.asarray(deskewed_prelim)
-    full_deskew_matrix = np.linalg.inv(reverse_aff._matrix)  # get aff matrix for raw->deskewed, incl. translation
-    # get the 8 ROI box corners in raw space: same corners as calculate_crop_bbox
-    # but clipped to the volume, in xyz order with a homogeneous 1
-    from itertools import product
-
-    sub_corners = np.asarray([
-        [x, y, z, 1]
-        for x, y, z in product((x_start, x_end), (y_start, y_end), (z_start_vol, z_end_vol))
-    ])
-    prelim_corners = (full_deskew_matrix @ sub_corners.T).T  # deskewed xyz of sub-block corners
-    roi_origin = np.asarray(crop_bounding_box).min(axis=0)   # [x, y, z, 1]
+    crop_excess = geometry.crop_excess
 
     if skew_dir == DeskewDirection.Y:
-        crop_height = crop_vol_shape[1]
-        crop_excess: int = max(int(round(roi_origin[1] - prelim_corners[:, 1].min())), 0)
+        crop_height = geometry.crop_vol_shape[1]
         deskewed_crop = deskewed_prelim[:, crop_excess : crop_height + crop_excess, :]
         # Pad the skew axis if the prelim is short near the far field edge
         if deskewed_crop.shape[1] < crop_height:
             pad = crop_height - deskewed_crop.shape[1]
             deskewed_crop = np.pad(deskewed_crop, ((0, 0), (0, pad), (0, 0)))
     elif skew_dir == DeskewDirection.X:
-        crop_width = crop_vol_shape[2]
-        crop_excess = max(int(round(roi_origin[0] - prelim_corners[:, 0].min())), 0)
+        crop_width = geometry.crop_vol_shape[2]
         deskewed_crop = deskewed_prelim[:, :, crop_excess : crop_width + crop_excess]
         if deskewed_crop.shape[2] < crop_width:
             pad = crop_width - deskewed_crop.shape[2]
@@ -332,8 +419,9 @@ def crop_volume_deskew(
 
 def _crop_volume_deskew_shear_only(
     original_volume,
-    crop_bounding_box,
-    crop_vol_shape,
+    roi_shape,
+    z_start: int,
+    z_end: int,
     angle_in_degrees: float,
     voxel_size_x: float,
     voxel_size_y: float,
@@ -348,11 +436,11 @@ def _crop_volume_deskew_shear_only(
 ):
     """Crop + deskew for the coverslip frame (see caller for the rationale).
 
-    The crop ROI (``crop_bounding_box``, coverslip-frame corners as [x, y, z, 1])
-    is mapped to raw scan/Y/X via the frozen coverslip inverse map; the raw
-    sub-volume is extracted (with a 1px halo for interpolation), deskewed into the
-    shear-only (coverslip) frame with ``shear_only_deskew``, then trimmed to the ROI's
-    shear-only extent using the sub-block shear-only offset (a pure translation).
+    The crop ROI (coverslip-frame corners) is mapped to raw scan/Y/X via the frozen
+    coverslip inverse map; the raw sub-volume is extracted (with a 1px halo for
+    interpolation), deskewed into the shear-only (coverslip) frame with
+    ``shear_only_deskew``, then trimmed to the ROI's shear-only extent using the
+    sub-block shear-only offset (a pure translation).
     """
     from lls_core.shear_only_deskew import shear_only_deskew
     from lls_core.shear_only_geometry import (
@@ -361,6 +449,7 @@ def _crop_volume_deskew_shear_only(
     )
 
     skew_name = "Y" if skew_dir == DeskewDirection.Y else "X"
+    crop_bounding_box, crop_vol_shape = calculate_crop_bbox(roi_shape, z_start, z_end)
     Nz, Ny, Nx = (int(s) for s in original_volume.shape)
 
     # Map shear-only ROI corners -> raw (scan p, raw_y, raw_x) via the frozen inverse

--- a/core/lls_core/metadata.py
+++ b/core/lls_core/metadata.py
@@ -1,0 +1,234 @@
+"""
+Coordinate-transform and provenance metadata for output files.
+
+Every image a `Writer` produces gets a sibling `<name>.lattice.json` recording the deskew
+geometry that was applied and where the output sits in the full deskewed volume. See
+`docs/miscellaneous/output_metadata.md` for the document layout and how to consume it.
+"""
+from __future__ import annotations
+
+import json
+from enum import Enum
+from pathlib import Path, PurePath
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from lls_core.models.lattice_data import LatticeData
+
+#: Bumped when the document layout changes in a way consumers must notice.
+SCHEMA_VERSION = "1.0"
+
+SIDECAR_SUFFIX = ".lattice.json"
+
+#: Stripped when naming a sidecar. Listed explicitly rather than removing every suffix,
+#: so a dot in the base name (`sample.v2_deskewed.ome.tif`) survives.
+_OUTPUT_SUFFIXES = frozenset({".ome", ".tif", ".tiff", ".zarr", ".h5"})
+
+AFFINE_CONVENTION = (
+    "4x4 row-major homogeneous matrix in ZYX order, mapping a RAW voxel index "
+    "[z, y, x, 1] to a voxel index in the full deskewed volume. Multiply componentwise "
+    "by output_voxel_size_um for microns. This records the transform that was APPLIED - "
+    "the saved pixels are already deskewed, so it relates them back to the raw "
+    "acquisition rather than being something to apply again."
+)
+
+ORIGIN_REFERENCE = (
+    "Voxel (0, 0, 0) of the full deskewed volume of this acquisition, in deskewed voxels."
+)
+
+
+def _jsonable(value: Any) -> Any:
+    """
+    Coerce a pydantic `.dict()` tree into something `json.dumps` accepts.
+
+    numpy scalars are the main hazard: the repo pins `numpy<2`, where `np.float32` and
+    `np.int64` both raise from the stdlib encoder rather than degrading.
+    """
+    # Checked before `str`: the StrEnums here are `str` subclasses and would otherwise
+    # never reach this branch. Everything round-trips by NAME - `DeskewDirection` is an
+    # IntEnum whose value is a meaningless ordinal (Y == 2).
+    if isinstance(value, Enum):
+        return value.name
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, range):
+        # The config schema spells a range as [start, stop] - see the YAML examples.
+        return [int(value.start), int(value.stop)]
+    if isinstance(value, PurePath):
+        return str(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return _jsonable(value.tolist())
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return str(value)
+
+
+def build_config(lattice: "LatticeData") -> dict:
+    """
+    The run configuration, in the same schema as `--json-config` / `--yaml-config`.
+
+    `input_image`, `workflow` and `deconvolution.psf` hold loaded objects that cannot be
+    serialised back to the config that produced them, so the source path is recorded
+    instead - or `null` where the input was supplied in memory.
+    """
+    config = lattice.dict(exclude={"input_image", "input_image_path", "derived", "workflow_path"})
+
+    config["input_image"] = str(lattice.input_image_path) if lattice.input_image_path else None
+    if lattice.workflow is not None:
+        config["workflow"] = str(lattice.workflow_path) if lattice.workflow_path else None
+
+    decon = config.get("deconvolution")
+    if isinstance(decon, dict):
+        psf_paths = decon.pop("psf_paths", None)
+        # `[]` rather than `None` matches the declared `List` type. Note that when the
+        # PSFs were passed in memory there are no paths to record, and such a config
+        # cannot be re-run: a validator requires one PSF per channel.
+        decon["psf"] = [str(p) for p in psf_paths] if psf_paths else []
+
+    # A console affordance, not a property of the data
+    config.pop("progress_bar", None)
+
+    return _jsonable(config)
+
+
+def _crops(lattice: "LatticeData") -> bool:
+    """
+    Whether this output is one ROI of a cropped run.
+
+    `save_mip` is excluded because `LatticeData.save()` projects straight from the raw
+    data and ignores cropping, so an attached `crop` describes nothing about the output.
+    """
+    return bool(lattice.cropping_enabled and lattice.crop is not None and not lattice.save_mip)
+
+
+def output_origin_zyx(
+    lattice: "LatticeData", roi_index: Optional[int] = None
+) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    """
+    Position of this output's voxel (0, 0, 0) in the full deskewed volume, in deskewed
+    voxels.
+
+    An uncropped run is the whole volume, so its origin is the origin. A MIP has
+    collapsed Z, so its Z origin is `None` rather than a number that would invite misuse.
+    """
+    if lattice.save_mip:
+        return (None, 0.0, 0.0)
+    if not _crops(lattice):
+        return (0.0, 0.0, 0.0)
+
+    from lls_core.estimate import _roi_to_shape_array
+    from lls_core.utils import calculate_crop_bbox
+
+    index = 0 if roi_index is None else int(roi_index)
+    roi_shape = _roi_to_shape_array(lattice.crop.roi_list[index])
+    z_start, z_end = lattice.crop.z_range
+
+    if not lattice.coverslip_rotation:
+        # The shear-only trim aligns all three axes to the ROI, zero-padding where the
+        # sub-block falls short, so the origin is just the ROI origin. See the `_trim`
+        # closure in `_crop_volume_deskew_shear_only`.
+        crop_bounding_box, _ = calculate_crop_bbox(roi_shape, z_start, z_end)
+        x0, y0, z0 = np.asarray(crop_bounding_box).min(axis=0)[:3]
+        return (float(z0), float(y0), float(x0))
+
+    # The objective branch trims only the skew axis to the ROI, so its origin is not the
+    # ROI's - read it off the same helper the crop uses rather than re-deriving it.
+    from lls_core.llsz_core import objective_crop_geometry
+
+    return objective_crop_geometry(
+        raw_shape_zyx=tuple(int(s) for s in lattice.get_3d_slice().shape[-3:]),
+        roi_shape=roi_shape,
+        z_start=z_start,
+        z_end=z_end,
+        angle_in_degrees=lattice.angle,
+        voxel_size_x=lattice.dx,
+        voxel_size_y=lattice.dy,
+        voxel_size_z=lattice.dz,
+        skew_dir=lattice.skew_dir,
+    ).origin_zyx
+
+
+def sidecar_path(image_path: Path) -> Path:
+    """
+    `<output name without its extension>.lattice.json`, beside the output.
+
+    The extension is stripped rather than appended to: `img.ome.tif.lattice.json` would
+    still match a `*.tif*` glob, so anything scanning a results directory for images
+    would pick the sidecar up and try to read JSON as an image.
+    """
+    name = image_path.name
+    while True:
+        stem, dot, suffix = name.rpartition(".")
+        if not dot or ("." + suffix.lower()) not in _OUTPUT_SUFFIXES:
+            break
+        name = stem
+    return image_path.with_name(name + SIDECAR_SUFFIX)
+
+
+def write_sidecar(
+    lattice: "LatticeData", image_path: Path, roi_index: Optional[int] = None
+) -> Path:
+    """Write the metadata sidecar beside `image_path` and return its path."""
+    from lls_core import __version__
+    from lls_core.estimate import _roi_to_shape_array
+
+    cropped = _crops(lattice)
+    index = (0 if roi_index is None else int(roi_index)) if cropped else None
+
+    origin_px = output_origin_zyx(lattice, index)
+    voxel = (float(lattice.new_dz), float(lattice.dy), float(lattice.dx))
+    origin_um = [None if o is None else o * v for o, v in zip(origin_px, voxel)]
+
+    roi = None
+    if cropped:
+        corners = _roi_to_shape_array(lattice.crop.roi_list[index])
+        ys, xs = corners[:, 0], corners[:, 1]
+        roi = {
+            "index": index,
+            # CropParams normalises every ROI source to deskewed pixels on the way in
+            "units": "Pixels",
+            "bbox_yx_px": {
+                "top": float(ys.min()), "left": float(xs.min()),
+                "bottom": float(ys.max()), "right": float(xs.max()),
+            },
+            "z_range": _jsonable(lattice.crop.z_range),
+        }
+
+    affine = lattice.derived.deskew_affine_transform_zyx if lattice.derived else None
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "generator": {"name": "napari-lattice", "version": __version__},
+        "output": {
+            "path": image_path.name,
+            "roi_index": index,
+            "projection": "mip" if lattice.save_mip else None,
+            "origin_zyx_px": _jsonable(list(origin_px)),
+            "origin_zyx_um": _jsonable(origin_um),
+            "origin_reference": ORIGIN_REFERENCE,
+        },
+        "roi": roi,
+        "derived": {
+            "output_voxel_size_um": {"z": voxel[0], "y": voxel[1], "x": voxel[2]},
+            "full_output_shape_zyx": _jsonable(
+                lattice.derived.deskew_vol_shape if lattice.derived else None
+            ),
+            "raw_to_deskewed_affine_zyx": (
+                _jsonable(np.asarray(affine)) if affine is not None else None
+            ),
+            "affine_convention": AFFINE_CONVENTION,
+        },
+        "config": build_config(lattice),
+    }
+
+    path = sidecar_path(image_path)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(document, handle, indent=2)
+    return path

--- a/core/lls_core/models/deconvolution.py
+++ b/core/lls_core/models/deconvolution.py
@@ -1,5 +1,7 @@
 
-from pydantic.v1 import Field, NonNegativeInt, validator
+from pathlib import Path
+
+from pydantic.v1 import Field, NonNegativeInt, root_validator, validator
 
 from typing_extensions import Any, List, Literal, Union
 
@@ -22,6 +24,14 @@ class DeconvolutionParams(FieldAccessModel):
         default=[],
         description="List of Point Spread Functions to use for deconvolution. Each of which should be a 3D array. Each PSF can also be provided as a `str` path, in which case they will be loaded from disk as images."
     )
+    psf_paths: List[Path] = Field(
+        default=[],
+        cli_hide=True,
+        description="Internal: the filesystem paths the PSFs were loaded from, if any. "
+                    "The validated `psf` field holds arrays, which cannot be serialised "
+                    "back to paths, so output metadata records these instead. "
+                    "Not a user-facing parameter."
+    )
     decon_num_iter: NonNegativeInt = Field(
         default=10,
         description="Number of iterations to perform in deconvolution"
@@ -30,6 +40,21 @@ class DeconvolutionParams(FieldAccessModel):
         default=0,
         description='Background value to subtract for deconvolution. Only used when `decon_processing` is set to `GPU`. This can either be a literal number, "auto" which uses the median of the last slice, or "second_last" which uses the median of the last slice.'
     )
+
+    @root_validator(pre=True)
+    def capture_psf_paths(cls, values: dict) -> dict:
+        "Record the PSF paths before `convert_image` replaces them with arrays."
+        from lls_core.types import is_pathlike
+
+        given = values.get("psf")
+        if given is None:
+            return values
+        if is_pathlike(given):
+            given = [given]
+        paths = [str(item) for item in given if is_pathlike(item)]
+        if paths:
+            values["psf_paths"] = paths
+        return values
 
     @validator("decon_processing", pre=True)
     def convert_decon(cls, v: Any):

--- a/core/lls_core/models/lattice_data.py
+++ b/core/lls_core/models/lattice_data.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from pathlib import Path
 from typing import Tuple, cast
 from pydantic.v1 import Field, root_validator, validator
 from dask.array.core import Array as DaskArray
@@ -116,6 +117,15 @@ class LatticeData(OutputParams, DeskewParams):
         cli_description="Path to a JSON file specifying a napari_workflow-compatible workflow to add lightsheet processing onto"
     )
 
+    workflow_path: Optional[Path] = Field(
+        default=None,
+        cli_hide=True,
+        description="Internal: the filesystem path the workflow was loaded from, if any. "
+                    "A `Workflow` object cannot be serialised back to a path, so output "
+                    "metadata records this instead. Mirrors `input_image_path`; "
+                    "not a user-facing parameter."
+    )
+
     progress_bar: bool = Field(
         default = True,
         description = "If true, show progress bars"
@@ -124,7 +134,6 @@ class LatticeData(OutputParams, DeskewParams):
     @root_validator(pre=True)
     def read_image(cls, values: dict):
         from lls_core.types import is_pathlike
-        from pathlib import Path
         input_image = values.get("input_image")
         logger.info(f"Processing File {input_image}") # this is handy for debugging
         if is_pathlike(input_image):
@@ -138,6 +147,12 @@ class LatticeData(OutputParams, DeskewParams):
             elif is_pathlike(save_dir):
                 # Convert a string path to a Path object
                 values["save_dir"] = Path(save_dir)
+
+        # A Workflow object does not remember where it was read from, so capture the
+        # path now - it is the only chance - for output metadata to record.
+        workflow = values.get("workflow")
+        if is_pathlike(workflow):
+            values["workflow_path"] = Path(workflow)
 
         # Use the Deskew version of this validator, to do the actual image loading
         return super().read_image(values)

--- a/core/lls_core/utils.py
+++ b/core/lls_core/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from os import devnull, path
-from typing import Collection, List, Optional, Tuple, TypeVar, Union
+from typing import Collection, List, NamedTuple, Optional, Tuple, TypeVar, Union
 from urllib import parse
 
 import numpy as np
@@ -45,6 +45,13 @@ def check_subclass(obj: Any, pkg_name: str, cls_name: str) -> bool:
 
 def is_napari_shape(obj: Any) -> TypeGuard[Shapes]:
     return check_subclass(obj, "napari.shapes", "Shapes")
+
+class ShapeOnly(NamedTuple):
+    """
+    Stand-in for a volume where only `.shape` is read, so the deskew shape and placement
+    math never has to allocate (or read) a volume that may be hundreds of gigabytes.
+    """
+    shape: Tuple[int, ...]
 
 def calculate_crop_bbox(shape: list, z_start: int, z_end: int) -> tuple[List[List[Any]], List[int]]:
     """Get bounding box as vertices in 3D in the form xyz

--- a/core/lls_core/writers.py
+++ b/core/lls_core/writers.py
@@ -109,9 +109,21 @@ class Writer(ABC):
 
     def close(self):
         """
-        Called when no more image slices are available, and the writer should finalise its output files
+        Called when no more image slices are available, and the writer should finalise
+        its output files, then describe each one with a metadata sidecar.
+
+        Sidecar paths come from `written_files` rather than being recomputed:
+        `get_unique_filepath` renames on collision, so a recomputed name would drift off
+        the real file. A sidecar failure is logged, not raised - it must not lose the
+        pixels that were just written.
         """
-        pass
+        from lls_core.metadata import write_sidecar
+
+        for path in self.written_files:
+            try:
+                write_sidecar(self.lattice, path, roi_index=self.roi_index)
+            except Exception:
+                logger.warning("Could not write metadata sidecar for %s", path, exc_info=True)
 
     def write_all(self, slices: Iterable[ProcessedSlice[ArrayLike]]) -> None:
         """
@@ -166,6 +178,7 @@ class BdvWriter(Writer):
     def close(self):
         self.bdv_writer.write_xml()
         self.bdv_writer.close()
+        super().close()
 
 @dataclass
 class TiffWriter(Writer):
@@ -263,6 +276,7 @@ class TiffWriter(Writer):
 
     def close(self):
         self.flush()
+        super().close()
 
     def write_all(self, slices: Iterable[ProcessedSlice[ArrayLike]]) -> None:
         """
@@ -340,6 +354,9 @@ class TiffWriter(Writer):
                 metadata=ome_metadata,
             )
         self.written_files.append(path)
+        # This path returns without going through the base `write_all`, so `close()`
+        # would never fire and the output would get no sidecar.
+        self.close()
 
 @dataclass
 class OMEZarrWriter(Writer):
@@ -405,6 +422,9 @@ class OMEZarrWriter(Writer):
         # If it's the first slice - initialize the full zarr array size
         if self._arr is None:
             self._root_group, self._arr = self._create_store(t_len, c_len, self._zyx, self._dtype)
+            # Record the store so it is reported like the other formats' outputs, and
+            # so `close()` writes it a metadata sidecar.
+            self.written_files.append(self._root_path)
 
         self._arr[t_idx, c_idx, :, :, :] = to_output_dtype(data3d, self._arr.dtype)
         return self._root_path

--- a/core/tests/test_metadata_sidecar.py
+++ b/core/tests/test_metadata_sidecar.py
@@ -1,0 +1,249 @@
+"""
+Tests for the `.lattice.json` metadata sidecar.
+
+The load-bearing test is `test_recorded_origin_matches_pixels`: it deskews a full volume
+and an ROI of it independently, finds where the ROI *actually* landed by scanning for the
+best-matching window, and asserts the recorded origin agrees. That checks the metadata
+against pixel reality rather than a restatement of the same formula, which is the only way
+to catch the origin drifting from what the crop does.
+"""
+import json
+
+import numpy as np
+import pytest
+import pyclesperanto_prototype as cle
+from xarray import DataArray
+
+from lls_core import DeskewDirection
+from lls_core.metadata import SIDECAR_SUFFIX, build_config, output_origin_zyx, sidecar_path
+from lls_core.models.lattice_data import LatticeData
+from lls_core.models.output import SaveFileType
+
+
+def _image(shape=(1, 1, 30, 40, 35)):
+    rng = np.random.default_rng(0)
+    return DataArray(rng.integers(0, 500, shape, dtype=np.uint16), dims=("T", "C", "Z", "Y", "X"))
+
+
+def _lattice(tmp_path, **kwargs):
+    params = dict(
+        input_image=_image(),
+        physical_pixel_sizes=(0.3, 0.15, 0.15),
+        save_dir=tmp_path,
+        save_name="meta",
+        progress_bar=False,
+    )
+    params.update(kwargs)
+    return LatticeData(**params)
+
+
+def _sidecars(directory):
+    return sorted(directory.glob("*" + SIDECAR_SUFFIX))
+
+
+def _only_sidecar(directory):
+    found = _sidecars(directory)
+    assert len(found) == 1, f"expected one sidecar, got {[p.name for p in found]}"
+    return json.loads(found[0].read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("save_type", [SaveFileType.tiff, SaveFileType.h5, SaveFileType.omezarr])
+def test_sidecar_written_for_each_format(tmp_path, save_type):
+    """Every format gets a parseable sidecar that names the file it sits beside."""
+    _lattice(tmp_path, save_type=save_type, angle=32.5).save()
+    document = _only_sidecar(tmp_path)
+
+    # Must name the file actually written, not a recomputed name
+    assert (tmp_path / document["output"]["path"]).exists()
+
+    derived = document["derived"]
+    matrix = np.asarray(derived["raw_to_deskewed_affine_zyx"])
+    assert matrix.shape == (4, 4)
+    assert np.allclose(matrix[3], [0, 0, 0, 1]), "not a homogeneous matrix"
+    assert derived["output_voxel_size_um"]["y"] == pytest.approx(0.15)
+
+
+@pytest.mark.parametrize("filename,expected", [
+    ("img_deskewed.ome.tif", "img_deskewed.lattice.json"),
+    # A dot in the base name must survive the stripping
+    ("sample.v2_deskewed.ome.zarr", "sample.v2_deskewed.lattice.json"),
+])
+def test_sidecar_name_drops_the_image_extension(tmp_path, filename, expected):
+    """
+    Appending would leave `img.ome.tif.lattice.json`, which still matches a `*.tif*` glob,
+    so anything scanning a results directory for images would try to read it as an image.
+    """
+    assert sidecar_path(tmp_path / filename).name == expected
+
+
+def test_origins_for_uncropped_and_mip(tmp_path):
+    """The two cases with no ROI geometry to resolve."""
+    _lattice(tmp_path, save_type=SaveFileType.tiff).save()
+    document = _only_sidecar(tmp_path)
+    assert document["output"]["origin_zyx_px"] == [0.0, 0.0, 0.0]
+    assert document["roi"] is None
+
+    mip_dir = tmp_path / "mip"
+    mip_dir.mkdir()
+    _lattice(mip_dir, save_dir=mip_dir, save_type=SaveFileType.tiff, save_mip=True).save()
+    output = _only_sidecar(mip_dir)["output"]
+    assert output["projection"] == "mip"
+    # Z is projected away, so a Z position would be meaningless rather than unknown
+    assert output["origin_zyx_px"][0] is None
+
+
+def test_mip_ignores_an_attached_crop(tmp_path):
+    """
+    `LatticeData.save()` projects a MIP straight from the raw data and ignores cropping,
+    so an attached crop describes nothing about the output. Reporting it would contradict
+    the whole-FOV origin in the same document.
+    """
+    roi = np.array([[5.0, 4.0], [5.0, 20.0], [24.0, 20.0], [24.0, 4.0]])
+    _lattice(tmp_path, save_type=SaveFileType.tiff, save_mip=True,
+             crop={"roi_list": [roi], "z_range": (2, 12)}).save()
+
+    document = _only_sidecar(tmp_path)
+    assert document["roi"] is None
+    assert document["output"]["roi_index"] is None
+    assert document["output"]["origin_zyx_px"] == [None, 0.0, 0.0]
+
+
+def test_each_roi_gets_its_own_placement(tmp_path):
+    rois = [
+        np.array([[5.0, 4.0], [5.0, 20.0], [24.0, 20.0], [24.0, 4.0]]),
+        np.array([[40.0, 6.0], [40.0, 22.0], [60.0, 22.0], [60.0, 6.0]]),
+    ]
+    _lattice(tmp_path, save_type=SaveFileType.tiff,
+             crop={"roi_list": rois, "z_range": (2, 12)}).save()
+
+    documents = [json.loads(p.read_text(encoding="utf-8")) for p in _sidecars(tmp_path)]
+    by_index = {d["output"]["roi_index"]: d for d in documents}
+    assert set(by_index) == {0, 1}
+    assert (by_index[0]["output"]["origin_zyx_px"]
+            != by_index[1]["output"]["origin_zyx_px"]), "distinct ROIs reported one origin"
+
+    roi = by_index[1]["roi"]
+    assert roi["bbox_yx_px"]["top"] == pytest.approx(40.0)
+    assert roi["z_range"] == [2, 12]
+
+
+def test_config_block_round_trips(tmp_path, image_workflow):
+    """The `config` block must be usable as `--json-config`."""
+    lattice = _lattice(
+        tmp_path,
+        save_type=SaveFileType.tiff,
+        angle=32.0,
+        skew="X",
+        invert_scan_direction=True,
+        crop={"roi_list": [np.array([[5.0, 4.0], [5.0, 20.0], [24.0, 20.0], [24.0, 4.0]])],
+              "z_range": (1, 9)},
+    )
+    lattice.save()
+    config = _only_sidecar(tmp_path)["config"]
+
+    # input_image is null here (the image was passed in memory), so supply one to satisfy
+    # the required field; everything else must survive the same parsing the CLI does.
+    rebuilt = LatticeData.parse_obj({**config, "input_image": _image(), "progress_bar": False})
+    assert rebuilt.angle == 32.0
+    assert rebuilt.skew == DeskewDirection.X
+    assert rebuilt.invert_scan_direction is True
+    assert rebuilt.save_type == SaveFileType.tiff
+    assert rebuilt.crop.z_range == (1, 9)
+    assert list(rebuilt.time_range) == list(lattice.time_range)
+    np.testing.assert_allclose(np.asarray(rebuilt.crop.roi_list[0]),
+                               np.asarray(lattice.crop.roi_list[0]))
+
+    # A Workflow object cannot be serialised, so the source path is what gets recorded
+    from napari_workflows._io_yaml_v1 import save_workflow
+
+    workflow_path = tmp_path / "flow.yml"
+    save_workflow(str(workflow_path), image_workflow)
+    with_workflow = _lattice(tmp_path, save_type=SaveFileType.tiff, workflow=workflow_path)
+    assert build_config(with_workflow)["workflow"] == str(workflow_path)
+
+
+def test_shear_only_origin_is_the_roi_origin(tmp_path):
+    """
+    The shear-only trim aligns all three axes to the ROI (zero-padding the leading edge
+    when needed), so unlike the objective branch its origin is exactly the ROI origin.
+    """
+    roi = np.array([[12.0, 8.0], [12.0, 28.0], [34.0, 28.0], [34.0, 8.0]])
+    lattice = _lattice(tmp_path, coverslip_rotation=False, save_type=SaveFileType.tiff,
+                       crop={"roi_list": [roi], "z_range": (3, 15)})
+    assert output_origin_zyx(lattice, roi_index=0) == pytest.approx((3.0, 12.0, 8.0))
+
+
+@pytest.mark.parametrize("skew", ["Y", "X"])
+def test_recorded_origin_matches_pixels(tmp_path, skew):
+    """
+    The origin in the sidecar must be where the crop's pixels really are.
+
+    Verified by sliding the crop along the full deskewed volume and taking the offset with
+    the lowest error, so this fails if the recorded origin drifts from what
+    `crop_volume_deskew` does - the trap being that only the skew axis is trimmed to the
+    ROI, so the other two axes' origins are not the ones that were asked for.
+    """
+    angle = 30.0
+    skew_dir = DeskewDirection.Y if skew == "Y" else DeskewDirection.X
+
+    # Uniform background with off-centre markers, wide along the shear axis
+    if skew == "Y":
+        raw = np.full((90, 260, 90), 30.0, np.float32)
+        for z, a in [(20, 60), (45, 130), (70, 200)]:
+            raw[z - 3:z + 3, a - 6:a + 6, 40:50] = 800.0
+    else:
+        raw = np.full((90, 90, 260), 30.0, np.float32)
+        for z, a in [(20, 60), (45, 130), (70, 200)]:
+            raw[z - 3:z + 3, 40:50, a - 6:a + 6] = 800.0
+
+    deskew = cle.deskew_y if skew == "Y" else cle.deskew_x
+    full = np.asarray(cle.pull(deskew(
+        raw, angle_in_degrees=angle, voxel_size_x=1, voxel_size_y=1, voxel_size_z=1)))
+
+    axis = 1 if skew == "Y" else 2          # sheared (wide) output axis
+    other = 2 if skew == "Y" else 1
+    size = 50
+    a0 = int(np.clip(0.7 * full.shape[axis] - size / 2, 0, full.shape[axis] - size))
+    b0 = full.shape[other] // 2 - size // 2
+
+    if skew == "Y":
+        roi = np.array([[a0, b0], [a0, b0 + size], [a0 + size, b0 + size], [a0 + size, b0]], float)
+    else:
+        roi = np.array([[b0, a0], [b0 + size, a0], [b0 + size, a0 + size], [b0, a0 + size]], float)
+
+    _lattice(
+        tmp_path,
+        input_image=DataArray(raw[np.newaxis, np.newaxis], dims=("T", "C", "Z", "Y", "X")),
+        physical_pixel_sizes=(1.0, 1.0, 1.0),
+        save_type=SaveFileType.tiff,
+        angle=angle,
+        skew=skew_dir,
+        crop={"roi_list": [roi], "z_range": (0, full.shape[0])},
+    ).save()
+
+    document = _only_sidecar(tmp_path)
+    recorded = document["output"]["origin_zyx_px"]
+
+    import tifffile
+    crop = np.asarray(tifffile.imread(tmp_path / document["output"]["path"])).astype(np.float32)
+    crop = crop.reshape(crop.shape[-3:])   # (T=1, C=1, Z, Y, X) -> (Z, Y, X)
+
+    depth = min(crop.shape[0], full.shape[0])
+    assert crop[:depth].std() > 1.0, "crop has no structure; the test would be vacuous"
+
+    width = crop.shape[axis]
+    fixed = int(round(recorded[other]))
+
+    def window(k):
+        if skew == "Y":
+            return full[:depth, k:k + width, fixed:fixed + crop.shape[2]]
+        return full[:depth, fixed:fixed + crop.shape[1], k:k + width]
+
+    errors = [float(np.mean(np.abs(window(k) - crop[:depth])))
+              for k in range(max(0, full.shape[axis] - width + 1))]
+    empirical = int(np.argmin(errors))
+
+    assert abs(empirical - recorded[axis]) <= 1, (
+        f"sidecar says the crop starts at {recorded[axis]:.2f} on axis {axis}, but its "
+        f"pixels match the full volume best at {empirical} (skew={skew})"
+    )

--- a/core/tests/test_parallel_processing.py
+++ b/core/tests/test_parallel_processing.py
@@ -317,10 +317,17 @@ def _assert_same_output_images(ser_dir: str, par_dir: str) -> None:
     byte-identical (only the plain ImageJ-TIFF ever was).
     """
     import tifffile
+
+    from lls_core.metadata import SIDECAR_SUFFIX
+
     ser_files = sorted(p.name for p in Path(ser_dir).iterdir())
     par_files = sorted(p.name for p in Path(par_dir).iterdir())
     assert ser_files == par_files, (ser_files, par_files)
     for name in ser_files:
+        # Metadata sidecars are not images, and their `config` block records the
+        # process_parallel each run used, so they are expected to differ here.
+        if name.endswith(SIDECAR_SUFFIX):
+            continue
         ser_img = tifffile.imread(Path(ser_dir) / name)
         par_img = tifffile.imread(Path(par_dir) / name)
         assert np.array_equal(ser_img, par_img), name

--- a/docs/miscellaneous/output_metadata.md
+++ b/docs/miscellaneous/output_metadata.md
@@ -1,0 +1,130 @@
+# Output metadata (`.lattice.json`)
+
+Every image napari-lattice writes gets a sibling JSON sidecar recording **how the data was
+produced** and **where it sits**. For `results/6h_deskewed_ROI_3.ome.tif` the sidecar would be
+`results/6h_deskewed_ROI_3.lattice.json`.
+
+The image extension is dropped rather than appended to, so the sidecar never matches a
+`*.tif*` glob and tools scanning a results folder for images will not trip over it.
+
+## Why
+
+Pixel data carries voxel size and little else. Two things are otherwise lost at write time:
+
+- **Provenance** — the deskew angle, skew direction, coverslip rotation, scan direction and
+  the raw→deskewed affine. The transform is computed for every run but was never saved.
+- **Placement** — where a cropped ROI sits in the parent volume. Every ROI file starts at
+  voxel `(0,0,0)`, so a set of ROIs from one acquisition could not be related to each other
+  or to the full field of view.
+
+## Layout
+
+```json
+{
+  "schema_version": "1.0",
+  "generator": { "name": "napari-lattice", "version": "3.1.1" },
+  "output": {
+    "path": "6h_deskewed_ROI_3.ome.tif",
+    "roi_index": 3,
+    "projection": null,
+    "origin_zyx_px": [64.0, 1180.0, 512.0],
+    "origin_zyx_um": [9.6, 176.91, 76.76],
+    "origin_reference": "Voxel (0, 0, 0) of the full deskewed volume ..."
+  },
+  "roi": {
+    "index": 3,
+    "units": "Pixels",
+    "bbox_yx_px": { "top": 1180.0, "left": 512.0, "bottom": 1660.0, "right": 832.0 },
+    "z_range": [64, 274]
+  },
+  "derived": {
+    "output_voxel_size_um": { "z": 0.15, "y": 0.1499, "x": 0.1499 },
+    "full_output_shape_zyx": [210, 3100, 2048],
+    "raw_to_deskewed_affine_zyx": [[...], [...], [...], [0, 0, 0, 1]],
+    "affine_convention": "4x4 row-major homogeneous matrix in ZYX order ..."
+  },
+  "config": { "angle": 30.0, "skew": "Y", "save_type": "tiff", "...": "..." }
+}
+```
+
+## `config` — the run, in the config-file schema
+
+The `config` block uses the **same schema as `--json-config` / `--yaml-config`**, so it is
+directly reusable:
+
+```bash
+# Pull the config back out of a result and re-run it
+python -c "import json,sys; json.dump(json.load(open(sys.argv[1]))['config'], sys.stdout)" \
+    results/6h_deskewed_ROI_3.lattice.json > rerun.json
+lls-pipeline process --json-config rerun.json
+```
+
+Run `lls-pipeline process --show-schema` to see the same field set documented.
+
+!!! warning "The config records absolute paths"
+
+    `input_image`, `save_dir`, `workflow` and PSF entries are written as absolute paths
+    from the machine that produced the data. Check before sharing sidecars outside your
+    group if those paths are sensitive.
+
+!!! note "Three fields record a path, not the value"
+
+    `input_image`, `workflow` and `deconvolution.psf` hold loaded objects in memory, which
+    cannot be serialised back to the config that produced them. The sidecar records the
+    source path instead, and each is empty when that input was supplied in memory (e.g.
+    from the napari plugin, or a script passing an array). The rest of the config is still
+    accurate, but that field cannot reproduce the run on its own.
+
+    One case is not merely incomplete but un-runnable: a **deconvolution** run whose PSFs
+    were passed as arrays records no PSF paths, and re-parsing then fails because a
+    validator requires one PSF per channel. Supply PSFs as paths if you want the config
+    to be re-runnable.
+
+## `origin_zyx_px` — placing an output back in the parent volume
+
+`origin_zyx_px` is the position of the output's voxel `(0,0,0)` within the **full deskewed
+volume**, in deskewed voxels; `origin_zyx_um` is the same in microns. Loading several ROIs
+into a shared coordinate system is then just a translation:
+
+```python
+import json
+from pathlib import Path
+import napari, tifffile
+
+viewer = napari.Viewer()
+for sidecar in sorted(Path("results").glob("*.lattice.json")):
+    meta = json.loads(sidecar.read_text())
+    image = tifffile.imread(Path("results") / meta["output"]["path"])
+    voxel = meta["derived"]["output_voxel_size_um"]
+    viewer.add_image(
+        image,
+        name=f"ROI {meta['output']['roi_index']}",
+        scale=(voxel["z"], voxel["y"], voxel["x"]),
+        translate=meta["output"]["origin_zyx_um"],
+    )
+```
+
+!!! warning "The origin is not the ROI you drew"
+
+    Cropping only trims the **skew axis** to the ROI; the other two axes keep the bounds the
+    clipped raw sub-block deskewed into. So the Z origin is the sub-block's minimum deskewed
+    Z, not `z_range[0]`, and if an ROI extends past what the raw data can produce the output
+    starts where the data actually begins. `origin_zyx_px` always describes where the pixels
+    *are*, which is what you want for placement — compare it against `roi.bbox_yx_px` if you
+    need to know whether the request was clipped.
+
+    An uncropped run has origin `[0, 0, 0]`. A MIP has a `null` Z origin, since Z is
+    projected away.
+
+## `raw_to_deskewed_affine_zyx`
+
+A 4×4 row-major homogeneous matrix in ZYX order, mapping a **raw** voxel index
+`[z, y, x, 1]` to a voxel index in the full deskewed volume.
+
+This records the transform that was **applied**. The saved pixels are already deskewed, so
+the matrix is for relating them back to the raw acquisition — not something to apply again.
+Multiply componentwise by `output_voxel_size_um` for microns.
+
+The matrix means different things in the two geometries, so read it together with
+`config.coverslip_rotation`: `true` (Zeiss LLS7 and similar) is the standard deskew with the
+coverslip rotation folded in; `false` is the shear-only OPM/SOPi frame.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
 - "Supporting Resources":
   - "Overview": miscellaneous/index.md
   - "Defining ROIs for cropping": miscellaneous/rois_cropping.md
+  - "Output metadata": miscellaneous/output_metadata.md
 plugins:
 - search
 - mkdocs-video:

--- a/plugin/napari_lattice/fields.py
+++ b/plugin/napari_lattice/fields.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Callable, List, Optional, Tuple, TYPE_CHECKING, Union
 from typing_extensions import TypeVar
 import pyclesperanto_prototype as cle
 from lls_core.deconvolution import DeconvolutionChoice
@@ -20,7 +20,6 @@ from lls_core.models import (
 from lls_core.cropping import RoiUnits
 from lls_core.models.deskew import DefinedPixelSizes
 from lls_core.models.output import SaveFileType
-from lls_core.workflow import workflow_from_path
 from magicclass import FieldGroup, MagicTemplate, field, magicclass, set_design, vfield
 from magicclass.fields import MagicField
 from magicclass.widgets import ComboBox, Label, Widget
@@ -790,13 +789,17 @@ class WorkflowFields(NapariFieldGroup):
     def _workflow_path(self, workflow_source: WorkflowSource) -> bool:
         return workflow_source == WorkflowSource.CustomPath
 
-    def _make_model(self) -> Optional[Workflow]:
+    def _make_model(self) -> Optional[Union[Workflow, Path]]:
         if not self.fields_enabled.value:
             return None
         if self.workflow_source.value == WorkflowSource.ActiveWorkflow:
+            # Assembled live in the viewer, so there is no file for the sidecar to name.
             return WorkflowManager.install(self.parent_viewer).workflow
-        else:
-            return workflow_from_path(self.workflow_path.value)
+        # Hand LatticeData the path rather than a loaded Workflow. Its `parse_workflow`
+        # validator performs the same load, and its root validator captures the path for
+        # the output metadata sidecar. Loading here would discard it: a Workflow does not
+        # remember where it was read from, so this is the only chance to keep it.
+        return self.workflow_path.value
 
 @magicclass
 class OutputFields(NapariFieldGroup):

--- a/plugin/tests/test_dock_widget.py
+++ b/plugin/tests/test_dock_widget.py
@@ -230,3 +230,35 @@ def test_parallel_roi_save_off_main_thread():
         produced = list(os.scandir(tmpdir))
         assert produced, "parallel ROI save produced no output files"
 
+
+def test_custom_workflow_is_handed_over_as_a_path(tmp_path):
+    """
+    The output metadata sidecar records the workflow by its source path, and a `Workflow`
+    object cannot say where it was read from. So these fields must hand `LatticeData` the
+    path and let its validators do the loading.
+
+    Regression: loading the workflow here instead threw the path away, and every run
+    configured through the GUI wrote `"workflow": null` into its sidecar.
+    """
+    from napari_lattice.fields import WorkflowSource
+
+    workflow_path = tmp_path / "flow.yml"
+    workflow_path.write_text("""!!python/object:napari_workflows._workflow.Workflow
+_tasks:
+  blurred: !!python/tuple
+  - !!python/name:pyclesperanto_prototype.gaussian_blur ''
+  - deskewed_image
+  - null
+  - 1
+  - 1
+  - 1
+""")
+
+    ui = LLSZWidget()
+    set_debug(ui)
+    fields = ui.LlszMenu.WidgetContainer.workflow_fields
+    fields.fields_enabled.value = True
+    fields.workflow_source.value = WorkflowSource.CustomPath
+    fields.workflow_path.value = workflow_path
+
+    assert fields._make_model() == workflow_path


### PR DESCRIPTION
Every output image now gets a sibling `<name>.lattice.json` recording where it sits in the full deskewed volume and how it was produced, so crops can be put back in context.

## Changes

- **`metadata.py` (new)** — writes the sidecar: output origin (deskewed voxels + µm), ROI bbox and z-range, voxel size, full deskewed shape, the raw→deskewed affine, and the full run config.
- **`writers.py`** — `Writer.close()` writes one sidecar per output file. Fixed two writers that never reached `close()`, and registered the Zarr store as an output. Sidecar failures are logged, not raised — they can't lose pixels.
- **`llsz_core.py`** — extracted `objective_crop_geometry()` as the single source of truth for where an objective-frame crop lands; the crop, bbox and metadata all read from it.
- **Bug fix (behaviour change)** — `crop_excess` assumed the ROI was centred in the deskewed sub-block, which only holds near scan centre, so off-centre ROIs in large datasets were mis-placed. It's now derived exactly from the transform.
- **Provenance** — `workflow_path` and `psf_paths` capture source paths before validators replace them with loaded objects.
- **Docs & tests** — `docs/miscellaneous/output_metadata.md` documents the layout; `test_metadata_sidecar.py` checks recorded origins against the full deskewed volume for both skew directions.

**Reviewer note:** the `crop_excess` fix changes output framing for cropped objective-mode runs with off-centre ROIs — worth checking against existing results.