### PR TITLE
Fix breaking CI

### DIFF
--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -13,8 +13,6 @@ on:
   schedule:
     - cron: "0 22 * * 0" # weekly, Sunday 22:00 UTC
   workflow_dispatch: {}
-  push:
-    branches: [ci_fix] # TEMPORARY, for testing on this branch - remove before merging to master.
 
 jobs:
   # ------------------------------------------------------------------
@@ -77,12 +75,26 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.create({
+            // Only file a new issue if one isn't already open for this job - otherwise
+            // a weekly red run would spam a fresh issue every time. Closing the issue
+            // is what re-arms it for the next failure.
+            const trackingLabel = "latest-deps:core";
+            const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `latest-deps: Core Tests (Ubuntu, py${{ matrix.python-version }}) failed - ${new Date().toISOString().slice(0,10)}`,
-              body: `A third-party dependency likely released a breaking change. See run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              labels: ["ci", "dependencies"]
+              state: "open",
+              labels: trackingLabel,
+            });
+            if (existing.length > 0) {
+              console.log(`Already tracked in #${existing[0].number} - not creating a duplicate.`);
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `latest-deps: Core Tests (Ubuntu) failing`,
+              body: `A third-party dependency likely released a breaking change. Latest failing run (py${{ matrix.python-version }}): ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nThis re-opens automatically on the next failure only after this issue is closed.`,
+              labels: ["ci", "dependencies", trackingLabel]
             })
 
   # ------------------------------------------------------------------
@@ -168,10 +180,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.create({
+            // Only file a new issue if one isn't already open for this job - otherwise
+            // a weekly red run would spam a fresh issue every time. Closing the issue
+            // is what re-arms it for the next failure.
+            const trackingLabel = "latest-deps:windows";
+            const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `latest-deps: Plugin Tests (Windows) failed - ${new Date().toISOString().slice(0,10)}`,
-              body: `A third-party dependency likely released a breaking change. See run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              labels: ["ci", "dependencies"]
+              state: "open",
+              labels: trackingLabel,
+            });
+            if (existing.length > 0) {
+              console.log(`Already tracked in #${existing[0].number} - not creating a duplicate.`);
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `latest-deps: Plugin Tests (Windows) failing`,
+              body: `A third-party dependency likely released a breaking change. Latest failing run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nThis re-opens automatically on the next failure only after this issue is closed.`,
+              labels: ["ci", "dependencies", trackingLabel]
             })

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: "0 22 * * 0" # weekly, Sunday 22:00 UTC
   workflow_dispatch: {}
+  push:
+    branches: [ci_fix] # TEMPORARY, for testing on this branch - remove before merging to master.
 
 jobs:
   # ------------------------------------------------------------------

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,0 +1,175 @@
+# Catch breaking releases from third-party dependencies (e.g. the pyopencl 2026.1.3
+# mako/Windows-loader regressions) before a user actually hits them via a fresh install.
+#
+# Deliberately NOT pinned: mirror docs/installation.md's real install
+# commands (`uv pip install -e '.[testing]'`, no version caps)
+# Does not blocks a push or PR, its just advisory
+#
+# Runs weekly
+
+name: latest-deps
+
+on:
+  schedule:
+    - cron: "0 22 * * 0" # weekly, Sunday 22:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  # ------------------------------------------------------------------
+  # JOB 1: Core, latest deps (Ubuntu)
+  # ------------------------------------------------------------------
+  test-core-latest:
+    name: Core Tests, latest deps (Ubuntu)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniforge-version: latest
+          conda-remove-defaults: "true"
+          auto-update-conda: true
+          activate-environment: test
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+
+      - name: Save conda location
+        run: echo "python=$(which python)" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.6.17"
+
+      - name: Install core
+        timeout-minutes: 10
+        run: |
+          conda install -y pyqt pyopencl pocl pytest-qt "openssl!=3.6.3"
+          uv pip install --upgrade pip setuptools wheel
+          uv pip install -e './core[testing]'
+
+      - name: Verify TLS stack
+        run: |
+          conda list openssl
+          python -c "import ssl; print(ssl.OPENSSL_VERSION); ssl.create_default_context(); import distributed; print('TLS OK')"
+
+      - name: Lint core
+        uses: ./.github/lint
+        with:
+          directory: core
+          python: ${{ env.python }}
+
+      - name: Test core
+        run: pytest --verbose --verbose core/
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `latest-deps: Core Tests (Ubuntu, py${{ matrix.python-version }}) failed - ${new Date().toISOString().slice(0,10)}`,
+              body: `A third-party dependency likely released a breaking change. See run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ["ci", "dependencies"]
+            })
+
+  # ------------------------------------------------------------------
+  # JOB 2: Plugin, latest deps (Windows)
+  # ------------------------------------------------------------------
+  test-plugin-latest:
+    name: Plugin Tests, latest deps (Windows)
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        os: [windows-latest]
+
+    env:
+      QT_API: pyqt6
+      PYTEST_QT_API: pyqt6
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniforge-version: latest
+          conda-remove-defaults: "true"
+          auto-update-conda: true
+          activate-environment: test
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+
+      - name: Save conda location
+        run: echo "python=$(which python)" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.6.17"
+
+      - name: Install core & plugin
+        timeout-minutes: 10
+        run: |
+          conda install -y oclgrind khronos-opencl-icd-loader "openssl!=3.6.3"
+          uv pip install --upgrade pip setuptools wheel
+          uv pip install -e './core[testing]'
+          uv pip install -e './plugin[testing]'
+          # Deliberately no pyopencl cap here, unlike test_and_deploy.yml - this job
+          # exists to find out when the cap can be dropped, not to avoid the problem.
+
+      - name: Verify TLS stack
+        run: |
+          conda list openssl
+          python -c "import ssl; print(ssl.OPENSSL_VERSION); ssl.create_default_context(); import distributed; print('TLS OK')"
+
+      - name: Register oclgrind OpenCL ICD
+        shell: pwsh
+        run: |
+          $dll = Get-ChildItem "$env:CONDA\envs\test\Library\bin" -Filter "*oclgrind*" | Select-Object -First 1
+          Write-Host "Found: $($dll.FullName)"
+          $regPath = "HKLM:\SOFTWARE\Khronos\OpenCL\Vendors"
+          if (-not (Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }
+          New-ItemProperty -Path $regPath -Name $dll.FullName -Value 0 -PropertyType DWORD -Force | Out-Null
+          Write-Host "Registered oclgrind in OpenCL ICD registry"
+
+      - name: Install Windows OpenGL
+        run: |
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
+          powershell gl-ci-helpers/appveyor/install_opengl.ps1
+
+      - name: Lint plugin
+        uses: ./.github/lint
+        with:
+          directory: plugin
+          python: ${{ env.python }}
+
+      - name: Test plugin
+        timeout-minutes: 18
+        run: pytest -v plugin
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `latest-deps: Plugin Tests (Windows) failed - ${new Date().toISOString().slice(0,10)}`,
+              body: `A third-party dependency likely released a breaking change. See run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ["ci", "dependencies"]
+            })

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -143,6 +143,8 @@ jobs:
           # Install core and plugin
           uv pip install -e './core[testing]'
           uv pip install -e './plugin[testing]'
+          # ci only as pyopencl 2026.1.3 fails on windows; drop in next pyopencl release
+          uv pip install "pyopencl<=2026.1.2"
 
       # Fails loudly here rather than inside an unrelated napari traceback. Any
       # dask compute imports `distributed`, which builds an SSL context at import

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -45,6 +45,8 @@ dependencies = [
     "dask[distributed]",
     "fsspec>=2022.8.2",
     "importlib_resources",
+    # Not imported by us, but pyopencl >=2026.1.3 imports it at module load
+    "mako", 
     "napari-workflows>=0.2.8",
     "npy2bdv",
     "numba",
@@ -55,9 +57,7 @@ dependencies = [
     # Imported directly in lls_core.czi_reader for fast CZI reads. Same library
     # bioio-czi uses by default, so output matches bioio (also pulled in by it).
     "pylibczirw",
-    # pyopencl 2026.1.3 error with windows
-    "pyopencl; sys_platform != 'win32'",
-    "pyopencl<=2026.1.2; sys_platform == 'win32'",
+    "pyopencl",
     # This is the first pydantic version that supports the "compatibility mode"
     # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
     "pydantic>=1.10.17,<3",
@@ -105,8 +105,7 @@ docs = [
     "mkdocs-jupyter",
     # Includes fixes for Pydantic 1.X
     "fieldz>=0.1.0",
-    "griffe-fieldz",
-    "mako"
+    "griffe-fieldz"
 ]
 deploy = [
     "build",
@@ -173,7 +172,7 @@ ignore_unused = [
     "bioio-czi",
     "bioio-ome-tiff",
 
-    #used in docs
+    #used in docs and imported by pyopencl >=2026.1.3
     "mako",
 
 ]

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -55,7 +55,9 @@ dependencies = [
     # Imported directly in lls_core.czi_reader for fast CZI reads. Same library
     # bioio-czi uses by default, so output matches bioio (also pulled in by it).
     "pylibczirw",
-    "pyopencl", 
+    # pyopencl 2026.1.3 error with windows
+    "pyopencl; sys_platform != 'win32'",
+    "pyopencl<=2026.1.2; sys_platform == 'win32'",
     # This is the first pydantic version that supports the "compatibility mode"
     # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
     "pydantic>=1.10.17,<3",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     # Imported directly in lls_core.czi_reader for fast CZI reads. Same library
     # bioio-czi uses by default, so output matches bioio (also pulled in by it).
     "pylibczirw",
-    "pyopencl<=2026.1.2", # 2026.1.3 update broke ubuntu and windows builds
+    "pyopencl", 
     # This is the first pydantic version that supports the "compatibility mode"
     # https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment
     "pydantic>=1.10.17,<3",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     # The lower bound is because we need this Python 3.8 fix: https://github.com/hanjinliu/magic-class/pull/108
     "magic-class>=0.7.5",
     "magicgui<0.8.0",
-    "mako",
     "napari-workflow-inspector",
     "napari-workflows>=0.2.8",
     "napari[all]>=0.4.11",
@@ -114,9 +113,6 @@ ignore_unused = [
     "bioio-tifffile",
     "tifffile",
     "pylibczirw",
-
-    #used in docs
-    "mako",
 ]
 output_format = "human_detailed"  
 


### PR DESCRIPTION
Update to pyopencl (2026.1.3) resulted in build failures in Windows. 

Added `mako` as a core dependency because `pyopencl >=2026.1.3` imports it at module load, ensuring that it is available when needed.